### PR TITLE
docs: 安装命令指向公开仓库 NanmiCoder/dsh-agent-teams

### DIFF
--- a/.dsh/skills/dsh-plugin-development/SKILL.md
+++ b/.dsh/skills/dsh-plugin-development/SKILL.md
@@ -4,7 +4,7 @@ description: 开发、维护、分发和验证 DeepSeek Harness (DSH) 插件的�
 metadata:
   version: "3.1.0"
   date: "2026-08-13"
-  reference: "https://github.com/dsh-external/dsh-agent-teams"
+  reference: "https://github.com/NanmiCoder/dsh-agent-teams"
 ---
 
 # DSH 插件开发

--- a/README.md
+++ b/README.md
@@ -16,12 +16,10 @@ DeepSeek Harness 的 AgentTeams 插件：安装后，任何会话只需一句自
 - 已安装或可通过 `npx` 使用 DeepSeek Harness
 
 ```sh
-npx -p @deepseek-ai/dsh dsh plugin --profile web add github:dsh-external/dsh-agent-teams
+npx -p @deepseek-ai/dsh dsh plugin --profile web add github:NanmiCoder/dsh-agent-teams
 ```
 
-该命令直接从 GitHub 仓库安装插件，无需 npm 包。`dsh plugin` 会把插件加入 `web` profile，并根据包内的 `dsh.bundle` 声明自动启用它；工具、系统提示和 Web 客户端入口随该 profile 一起加载。
-
-> **私有仓库凭证**：本仓库不公开，`github:` 安装依赖本机 git 对 `dsh-external/dsh-agent-teams` 的读取权限（已配置的 SSH key，或带 `repo` 权限的 HTTPS token），否则拉取时认证会失败。
+该命令直接从公开 GitHub 仓库安装插件，无需 npm 包，也无需任何凭证。`dsh plugin` 会把插件加入 `web` profile，并根据包内的 `dsh.bundle` 声明自动启用它；工具、系统提示和 Web 客户端入口随该 profile 一起加载。
 
 > **重启生效**：安装完成后，重启正在运行的 DeepSeek Harness Web 服务并刷新页面。
 
@@ -38,7 +36,7 @@ npx -p @deepseek-ai/dsh dsh plugin --profile web add github:dsh-external/dsh-age
 仓库按开放 Agent Skills 规范提供 [`dsh-plugin-development`](skills/dsh-plugin-development/SKILL.md)，可直接安装：
 
 ```sh
-npx skills add dsh-external/dsh-agent-teams --skill dsh-plugin-development
+npx skills add NanmiCoder/dsh-agent-teams --skill dsh-plugin-development
 ```
 
 `skills/dsh-plugin-development/` 是唯一权威源码；`.dsh/skills/` 保存供 DSH 在本仓库作为 cwd 时自动发现的跨平台镜像。修改 Skill 后运行 `pnpm sync:skill`，`pnpm verify` 会检查镜像没有漂移。

--- a/skills/dsh-plugin-development/SKILL.md
+++ b/skills/dsh-plugin-development/SKILL.md
@@ -4,7 +4,7 @@ description: 开发、维护、分发和验证 DeepSeek Harness (DSH) 插件的�
 metadata:
   version: "3.1.0"
   date: "2026-08-13"
-  reference: "https://github.com/dsh-external/dsh-agent-teams"
+  reference: "https://github.com/NanmiCoder/dsh-agent-teams"
 ---
 
 # DSH 插件开发


### PR DESCRIPTION
## 问题

README 和 Skill 里的安装地址仍然指向内测期的私有仓库 `dsh-external/dsh-agent-teams`（已确认 `private: true`），所有用户执行安装命令都会在克隆阶段报 `Authentication failed` 并中止。

## 修改

- `README.md`：`dsh plugin --profile web add github:` 与 `npx skills add` 均改为 `NanmiCoder/dsh-agent-teams`
- `README.md`：删除「私有仓库凭证」提示（仓库已公开，无需 SSH key / token）
- `skills/dsh-plugin-development/SKILL.md` 及 `.dsh/` 镜像：`reference` 链接同步更新（`pnpm verify:skill` 通过）

## 验证

无凭证匿名克隆公开地址成功：

```
GIT_TERMINAL_PROMPT=0 git -c credential.helper= clone --depth 1 https://github.com/NanmiCoder/dsh-agent-teams.git
```

Fixes #5