### PR TITLE
fix(events): mark team session events ignorable so history survives unknown readers

### DIFF
--- a/src/events.ts
+++ b/src/events.ts
@@ -33,7 +33,12 @@ export function appendTeamEvent(
   data: SessionEventMap[AgentTeamsEventType],
 ): void {
   try {
-    session.append(type, data)
+    // Mark every team event `ignorable`: these records are purely informational
+    // (the team state is also durably persisted under `.agent-teams/`), and the
+    // `agent-teams/*` types are outside the harness core's known-event catalog.
+    // Without the marker a reader that does not recognize them refuses the whole
+    // session log with SessionFormatUnsupportedError instead of skipping them.
+    session.append(type, data, { ignorable: true })
   } catch (error: unknown) {
     ctx.logger.warn(`agent-teams: session record failed after ${type}: ${String(error)}`)
   }


### PR DESCRIPTION
# fix(events): mark team session events `ignorable` so history survives unknown readers

## Problem

Any session that runs AgentTeams becomes un-loadable afterwards. Opening that
session's history fails with:

```
SessionFormatUnsupportedError: session "…" contains event type
"agent-teams/team-created" (seq 25009) unknown to this harness and not marked
ignorable; refusing to interpret the log — it was likely written by a newer
harness (raw log: …/session.jsonl.zstd)
```

The whole session history is refused, not just the team events.

## Root cause

`appendTeamEvent` records team state into the captain's `Session` via
`session.append(type, data)` for seven custom event types:

`agent-teams/team-created`, `agent-teams/member-added`,
`agent-teams/member-removed`, `agent-teams/task-created`,
`agent-teams/task-updated`, `agent-teams/message-sent`,
`agent-teams/team-deleted`.

These are *downstream / out-of-repo* types, so they are — by design — outside
the harness core's static `KNOWN_SESSION_EVENT_TYPES` catalog
(`@deepseek-ai/dsh-session/known-event-types`). The persistence read path
(`assertEventsSupported`) therefore refuses any log containing a type it does
not recognize **unless** the event carries the envelope's `ignorable: true`
marker.

That marker exists on the read side (`SessionEvent.ignorable`), but the harness
core's `Session.append` currently has no write-side support for emitting it, so
our events are written as *required*. A reader that does not know the type then
has to refuse the entire log rather than skip the informational record.

## Why `ignorable` is correct here

Team events are purely informational for the conversation tree view. The
authoritative team state is already durably persisted separately under
`.agent-teams/`, so losing or skipping these events can never corrupt session
reconstruction. They are exactly the "purely informational records" the
`ignorable` marker was designed for.

## Change

In `src/events.ts`, emit every team event with the marker:

```ts
session.append(type, data, { ignorable: true })
```

## Dependency

This relies on the harness core accepting `ignorable` in `Session.append`.
Today the option is silently dropped at runtime and rejected by the TypeScript
signature for non-surface types
(`...opts: T extends SurfaceEventType ? [opts: SurfaceIntent] : []`). A
companion change on the harness side is required so the marker is actually
written and type-checks. See the corresponding deepseek-harness issue.

## Testing

Reproduced against a real session log containing 40 `agent-teams/*` events
(first at seq 25009):

- Before: the harness's own decode path
  (`decodeStorageRecord` + `adoptSessionEvent` + `KNOWN_SESSION_EVENT_TYPES`)
  reports 40 unsupported events → the log is refused.
- After marking the events `ignorable`, the same replay decodes all
  128,664 events with 0 unsupported → the log loads cleanly.
- `node --check` passes on the compiled output.

No behavior change for readers that *do* recognize the types: the web client's
`agent-teams` card matches on `event.type` and still renders identically.
