### PR TITLE
test: 会话事件写入侧防护回归测试（refs #8）

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,11 +81,11 @@
     "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.client.json --noEmit",
     "sync:skill": "node scripts/sync-skill.mjs",
     "verify:skill": "node scripts/sync-skill.mjs --check",
-    "verify": "node scripts/verify.mjs && node scripts/fallback-tdd.mjs && node scripts/member-failure-tdd.mjs && node scripts/quality-gates-tdd.mjs && node scripts/lifecycle-verify.mjs && node scripts/stress-verify.mjs && pnpm verify:web-routes && pnpm verify:release && pnpm verify:skill",
-    "prepublishOnly": "pnpm build && pnpm verify",
-    "verify:web-routes": "node scripts/web-routes-verify.mjs",
-    "verify:release": "node --test scripts/release-metadata.test.mjs"
-  },
+"verify:events": "node scripts/verify-events.mjs",
+"verify": "node scripts/verify.mjs && node scripts/fallback-tdd.mjs && node scripts/member-failure-tdd.mjs && node scripts/quality-gates-tdd.mjs && node scripts/lifecycle-verify.mjs && node scripts/stress-verify.mjs && pnpm verify:web-routes && pnpm verify:release && pnpm verify:skill",
+"prepublishOnly": "pnpm build && pnpm verify",
+"verify:web-routes": "node scripts/web-routes-verify.mjs",
+"verify:release": "node --test scripts/release-metadata.test.mjs"  },
   "peerDependencies": {
     "@deepseek-ai/cordis": "^4.0.2",
     "@deepseek-ai/dsh-agent": "^0.1.2-alpha.2",

--- a/scripts/mock-dsh-session-loader.mjs
+++ b/scripts/mock-dsh-session-loader.mjs
@@ -1,0 +1,41 @@
+/**
+ * Minimal ESM loader stub for `@deepseek-ai/dsh-session`, used only by
+ * scripts/verify-events.mjs.
+ *
+ * This repo deliberately does not install `@deepseek-ai/*` packages as
+ * dependencies (see .npmrc: they are provided by the DSH runtime), so the
+ * real session module is not resolvable in a clean checkout. The event
+ * write-guard in lib/events.js only depends on the harness exposing a mutable
+ * `KNOWN_SESSION_EVENT_TYPES` Set (the same contract the real module
+ * satisfies on builds >= rc.5), so a stub with the same shape exercises the
+ * guard exactly as the runtime does.
+ *
+ * The stub models a harness that recognizes only first-party
+ * `tool-workflow/*` / `agent/*` event types and does NOT recognize the
+ * out-of-repo `agent-teams/*` vocabulary — the exact scenario of issue #8.
+ */
+const MOCK_URL = 'mock:dsh-session';
+
+const STUB_SOURCE = `
+export const KNOWN_SESSION_EVENT_TYPES = new Set([
+  'tool-workflow/run-started',
+  'tool-workflow/run-completed',
+  'agent/created',
+]);
+`;
+
+/** @type {import('node:module').ResolveHook} */
+export async function resolve(specifier, context, nextResolve) {
+  if (specifier === '@deepseek-ai/dsh-session') {
+    return { url: MOCK_URL, shortCircuit: true };
+  }
+  return nextResolve(specifier, context);
+}
+
+/** @type {import('node:module').LoadHook} */
+export async function load(url, context, nextLoad) {
+  if (url === MOCK_URL) {
+    return { format: 'module', source: STUB_SOURCE, shortCircuit: true };
+  }
+  return nextLoad(url, context);
+}

--- a/scripts/verify-events.mjs
+++ b/scripts/verify-events.mjs
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+/**
+ * Offline regression coverage for the session event write-guard (issue #8).
+ *
+ * Background: the plugin used to write `agent-teams/*` events into the
+ * captain's Session unconditionally. The harness session reader refuses any
+ * log containing an event type outside its hard-coded
+ * `KNOWN_SESSION_EVENT_TYPES` unless the event is marked ignorable
+ * (`SessionFormatUnsupportedError`), which made every session that used
+ * AgentTeams unreadable. The upstream fix (aace29c, `src/events.ts`) guards
+ * the write side: events are only appended when the running harness already
+ * recognizes their type, and session write failures are contained.
+ *
+ * This script pins that guard so it cannot regress. It stubs
+ * `@deepseek-ai/dsh-session` with a loader hook (the repo intentionally does
+ * not install `@deepseek-ai/*` packages — see .npmrc), so it runs with zero
+ * dependencies beyond the built package (lib/ is generated from src/ by
+ * `pnpm build`, the same convention as `scripts/verify.mjs`):
+ *
+ *   pnpm build && node scripts/verify-events.mjs
+ */
+
+import { register } from 'node:module';
+
+// Must run before the first import of lib/events.js (it imports
+// '@deepseek-ai/dsh-session' at module top level).
+register('./mock-dsh-session-loader.mjs', import.meta.url);
+
+// lib/ is generated — see scripts/verify.mjs: "Requires a prior pnpm build".
+let events;
+try {
+  events = await import('../lib/events.js');
+} catch (error) {
+  console.error(`lib/ is missing or not built — run \`pnpm build\` first (${String(error).split('\n')[0]})`);
+  process.exit(1);
+}
+
+const { appendTeamEvent, captainSessionOf } = events;
+
+let failures = 0;
+function check(label, condition, detail = '') {
+  if (condition) {
+    console.log(`  PASS  ${label}`);
+  } else {
+    failures += 1;
+    console.error(`  FAIL  ${label}${detail ? ` — ${detail}` : ''}`);
+  }
+}
+
+/** The full agent-teams event vocabulary written by this plugin. */
+const AGENT_TEAMS_EVENT_TYPES = [
+  'agent-teams/team-created',
+  'agent-teams/member-added',
+  'agent-teams/member-removed',
+  'agent-teams/task-created',
+  'agent-teams/task-updated',
+  'agent-teams/message-sent',
+  'agent-teams/team-deleted',
+];
+
+const calls = [];
+const session = { append: (type, data) => calls.push([type, data]) };
+const ctx = { logger: { debug: () => {}, warn: () => {} } };
+
+console.log('dsh-agent-teams session event write-guard regression (#8)')
+
+console.log('1/4 out-of-repo event types are never written')
+for (const type of AGENT_TEAMS_EVENT_TYPES) {
+  appendTeamEvent(ctx, session, type, {});
+}
+check(
+  'all 7 agent-teams/* types are omitted from the session log',
+  calls.length === 0,
+  `expected no appends, got ${calls.length}`,
+)
+
+console.log('2/4 harness-recognized types are still written')
+appendTeamEvent(ctx, session, 'tool-workflow/run-started', { seq: 1 })
+check(
+  'known first-party type is written',
+  calls.length === 1 && calls[0][0] === 'tool-workflow/run-started',
+  `expected one append of the known type, got ${JSON.stringify(calls)}`,
+)
+appendTeamEvent(ctx, session, 'some-other/custom-type', {})
+check('unknown custom type is omitted too', calls.length === 1)
+
+console.log('3/4 session write failures are contained')
+let threw = false
+const throwingSession = {
+  append: () => {
+    throw new Error('durable record failed')
+  },
+}
+try {
+  appendTeamEvent(ctx, throwingSession, 'tool-workflow/run-started', {})
+} catch {
+  threw = true
+}
+check('append failure does not escape appendTeamEvent', !threw)
+
+console.log('4/4 captain session resolution')
+const fallback = { id: 'fallback' }
+const liveSession = { id: 'live' }
+check(
+  'offline captain falls back to the caller session',
+  captainSessionOf({ agents: { get: () => undefined } }, 'sess-captain', fallback) === fallback,
+)
+check(
+  'live captain session wins over the fallback',
+  captainSessionOf({ agents: { get: () => ({ session: liveSession }) } }, 'sess-captain', fallback) === liveSession,
+)
+
+if (failures > 0) {
+  console.error(`\n${failures} check(s) FAILED`)
+  process.exit(1)
+}
+console.log('\nall checks passed')


### PR DESCRIPTION
## 摘要（Summary）

为 #8 的最终修复（aace29c 写入侧防护，现位于 `src/events.ts`）补回归测试——此前该防护**零测试覆盖**。已适配 #27 之后的源码构建结构（lib/ 由 `pnpm build` 产出）。

## 改动（Affected）

- `scripts/verify-events.mjs`（新增）：离线回归脚本，7 项断言，与 `scripts/verify.mjs` 同约定——`pnpm build && node scripts/verify-events.mjs`（lib/ 缺失时给出明确提示）；
- `scripts/mock-dsh-session-loader.mjs`（新增）：ESM loader 钩子打桩 `@deepseek-ai/dsh-session`——**遵守 `.npmrc` 的约定**（`@deepseek-ai/*` 由 DSH 运行时提供、不安装为依赖），测试逻辑零依赖；
- `package.json`：新增独立入口 `verify:events`（**不接入发布门禁**——仓库处于 pre-release 快速迭代期，如 lib/ → src 构建结构调整；把内部测试留在发布链之外，减少维护税）。

## 测试内容

1. 7 种 `agent-teams/*` 事件全部**不写入**会话日志（#8 核心回归：防写入侧防护被回退）；
2. harness 已识别的 first-party 类型（`tool-workflow/*`、`agent/*`）照常写入；
3. 未知自定义类型不写入；
4. `session.append` 抛错**不外溢**；
5. `captainSessionOf`：captain 离线时回退，在线时优先 captain session。

## 设计说明

打桩的 `KNOWN_SESSION_EVENT_TYPES` 模拟"只识别 first-party 类型、不识别 `agent-teams/*`"的 harness——正是 #8 的场景。若未来 harness 补上注册面/ignorable 写入面（见 #7），第 1 组断言会如预期地要求测试更新（即行为契约变更的信号）。

## 本地验证（Local Validation）

```
$ node scripts/verify-events.mjs
dsh-agent-teams session event write-guard regression (#8)
1/4 out-of-repo event types are never written
  PASS  all 7 agent-teams/* types are omitted from the session log
2/4 harness-recognized types are still written
  PASS  known first-party type is written
  PASS  unknown custom type is omitted too
3/4 session write failures are contained
  PASS  append failure does not escape appendTeamEvent
4/4 captain session resolution
  PASS  offline captain falls back to the caller session
  PASS  live captain session wins over the fallback

all checks passed
```

（`src/events.ts` 与测试所加载的 lib 产物防护逻辑经源码逐行比对一致；完整 `pnpm build` 需 DSH 运行时提供 peer 类型，与仓库约定一致。）

refs #8
