### PR TITLE
fix: publish committed npm artifacts

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - 'v*.*.*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Package version to publish
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -28,28 +34,25 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           package-manager-cache: false
 
-      - name: Set up pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 10.33.0
-
       - name: Set up npm with trusted publishing support
         run: npm install --global npm@11.19.0
 
-      - name: Verify release tag
+      - name: Verify release version
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
         shell: bash
         run: |
           package_version="$(node --print "require('./package.json').version")"
-          test "${GITHUB_REF_NAME}" = "v${package_version}"
+          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
+            test "${GITHUB_REF_NAME}" = "v${package_version}"
+          else
+            test "${RELEASE_VERSION}" = "${package_version}"
+          fi
 
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Typecheck
-        run: pnpm typecheck
-
-      - name: Verify package
-        run: pnpm verify
+      - name: Verify committed package
+        run: |
+          node scripts/verify-package.mjs
+          npm pack --dry-run --ignore-scripts
 
       - name: Publish to npm
-        run: npm publish --access public
+        run: npm publish --ignore-scripts --access public

--- a/scripts/verify-package.mjs
+++ b/scripts/verify-package.mjs
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+
+import { access, readFile } from 'node:fs/promises'
+
+let failures = 0
+
+function check(label, condition, detail = '') {
+  if (condition) {
+    console.log(`  PASS  ${label}`)
+    return
+  }
+
+  failures += 1
+  console.error(`  FAIL  ${label}${detail ? ` — ${detail}` : ''}`)
+}
+
+console.log('dsh-agent-teams package verification')
+
+const pkg = JSON.parse(await readFile(new URL('../package.json', import.meta.url), 'utf8'))
+const patchText = await readFile(new URL('../cordis.patch.yml', import.meta.url), 'utf8')
+const patchName = patchText
+  .split('\n')
+  .filter(line => !/^\s*#/.test(line))
+  .find(line => /^\s*name:\s*\S/.test(line))
+  ?.match(/^\s*name:\s*(.+?)\s*$/)?.[1]
+  ?.replace(/^(['"])(.*)\1$/, '$2')
+
+check(
+  'cordis.patch.yml name matches the published package name',
+  patchName === pkg.name,
+  `patch has ${JSON.stringify(patchName)}, package.json has ${JSON.stringify(pkg.name)}`,
+)
+check(
+  'files[] ships the bundle patch and lib',
+  ['lib', 'cordis.patch.yml'].every(entry => pkg.files?.includes(entry)),
+  `files = ${JSON.stringify(pkg.files)}`,
+)
+check(
+  'scoped package publishes publicly',
+  !pkg.name.startsWith('@') || pkg.publishConfig?.access === 'public',
+  'scoped packages default to restricted without publishConfig.access = "public"',
+)
+
+for (const path of ['../lib/index.js', '../lib/client.js']) {
+  try {
+    await access(new URL(path, import.meta.url))
+    check(`${path.slice(3)} exists`, true)
+  } catch {
+    check(`${path.slice(3)} exists`, false)
+  }
+}
+
+const clientBundle = await readFile(new URL('../lib/client.js', import.meta.url), 'utf8')
+const registeredId = clientBundle.match(/__ModuleLoader__\.load\(\{\s*id:\s*"([^"]*)"/)?.[1]
+check(
+  'client bundle registers under the package name',
+  registeredId === pkg.name,
+  `bundle registers ${JSON.stringify(registeredId)}, package.json has ${JSON.stringify(pkg.name)}`,
+)
+
+if (failures > 0) {
+  console.error(`\n${failures} package verification check(s) failed`)
+  process.exitCode = 1
+} else {
+  console.log('\nPackage verification passed')
+}


### PR DESCRIPTION
## Summary
- make the npm release workflow independent of unpublished DeepSeek Harness peer packages
- verify the committed package contract and tarball without rebuilding it on the release runner
- add a guarded manual dispatch path so the failed v0.1.3 release can be recovered without moving its tag

## Why
The first v0.1.3 run failed before publishing because a clean GitHub runner cannot install the Harness development peers used by typecheck and the full offline verifier. The distributable `lib/` artifacts are intentionally committed and had already passed the full local verification before the release PR.

## Validation
- `node scripts/verify-package.mjs`
- `npm pack --dry-run --ignore-scripts`
- workflow YAML parse
- tag and manual version guard simulations