### PR TITLE
build: add prepare script so git-source installs build themselves

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,8 @@
     "sync:skill": "node scripts/sync-skill.mjs",
     "verify:skill": "node scripts/sync-skill.mjs --check",
     "verify": "node scripts/verify.mjs && pnpm verify:skill",
-    "prepublishOnly": "pnpm build && pnpm verify"
+    "prepublishOnly": "pnpm build && pnpm verify",
+    "prepare": "npm run build"
   },
   "peerDependencies": {
     "@deepseek-ai/cordis": "^4.0.1-rc.1",


### PR DESCRIPTION
## Problem

DeepSeek Harness plugin marketplaces install plugins from **pinned git commits** (`pnpm add git+https://github.com/NanmiCoder/dsh-agent-teams.git#<commit>`). pnpm fetches the repo tarball — which excludes the gitignored `lib/` build output — and without a `prepare` script it has no way to produce it, so the installed package is missing its entry points (`lib/index.js`, `lib/client.js`).

## Change

One line: `"prepare": "npm run build"`. pnpm runs `prepare` automatically after installing devDependencies for git-hosted dependencies, so a pinned-commit install now builds itself. npm publishes are unaffected (`prepublishOnly` already builds; the extra `prepare` build on publish is a harmless no-op duplicate).

## Verification

Clean-room at the current head `489c0078b5ebdc6d0c1fd3c9362ef5e4fb60c32e`:

```
pnpm install --frozen-lockfile   # ok
npm run build                    # tsc + tsc(client) + tsdown, exit 0
# lib/index.js and lib/client.js both produced
```

Context: we'd love to include dsh-agent-teams in a curated DSH starter pack; this is the only thing between it and one-command installs. Thanks for the plugin!