### PR TITLE
fix: preserve preset persona for team members

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,10 +90,11 @@ Defaults work without extra setup. A trusted profile can override member behavio
     memberProvider: spawn
     memberModel: deepseek-v4
     memberMaxDepth: 1
+    memberPersonaPlacement: system
     maxMembers: 8
 ```
 
-`memberProvider` is the sub-agent runtime backend (`spawn` / `fork`), not an LLM provider. Cross-LLM-provider routing uses the optional `provider` + `model` fields of `agent_teams_add_member`; `memberModel` is only a model default for all members.
+`memberProvider` is the sub-agent runtime backend (`spawn` / `fork`), not an LLM provider. Cross-LLM-provider routing uses the optional `provider` + `model` fields of `agent_teams_add_member`; `memberModel` is only a model default for all members. `memberPersonaPlacement` defaults to `system`, which preserves the original system-level member persona. Set it to `prompt` for trajectory-sensitive presets such as Anchored Standard: the member protocol moves into the initial user message and the child preset's `deployment:persona` remains unchanged.
 
 ## Boundaries
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -90,10 +90,11 @@ dsh web
     memberProvider: spawn
     memberModel: deepseek-v4
     memberMaxDepth: 1
+    memberPersonaPlacement: system
     maxMembers: 8
 ```
 
-这里的 `memberProvider` 指子 Agent 的运行后端（`spawn` / `fork`），不是 LLM provider。跨 LLM provider 由 `agent_teams_add_member` 的可选 `provider` + `model` 参数表达；`memberModel` 只是所有成员的模型默认覆盖。
+这里的 `memberProvider` 指子 Agent 的运行后端（`spawn` / `fork`），不是 LLM provider。跨 LLM provider 由 `agent_teams_add_member` 的可选 `provider` + `model` 参数表达；`memberModel` 只是所有成员的模型默认覆盖。`memberPersonaPlacement` 默认为 `system`，保持原有的系统级成员 persona；对于 Anchored Standard 等依赖首轮轨迹的 preset，可设为 `prompt`，把成员协议移入首条用户消息，并保持子 Agent preset 的 `deployment:persona` 不变。
 
 ## 使用边界
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -9,7 +9,7 @@
 | DSH 能力 | AgentTeams 用法 |
 |---|---|
 | `ctx.tools` 注册表 | 注册 9 个 `agent_teams_*` 工具（与 `tool-workflow` 同一注册路径） |
-| `ctx.subagents.startContinuable()` | 创建成员：durable 可续聊子代理，带成员 persona |
+| `ctx.subagents.startContinuable()` | 创建成员：durable 可续聊子代理；成员协议可放在系统 persona 或首条用户消息 |
 | `ctx.subagents.followup()` | 唤醒收件成员（消息进入其下一轮次） |
 | `ctx.subagents.listChildren()` | 查询成员实时活动（running / inactive） |
 | `ctx.systemPrompt.section()` | 注册"AgentTeams 使用策略"提示段 |
@@ -45,7 +45,7 @@
 | 工具 | 作用 |
 |---|---|
 | `agent_teams_create` | 创建团队，调用者成为队长（一个队长同时只带一个团队） |
-| `agent_teams_add_member` | 拉成员入队（spawn 可续聊子代理 + 成员 persona） |
+| `agent_teams_add_member` | 拉成员入队（spawn 可续聊子代理 + 可配置的成员协议注入） |
 | `agent_teams_remove_member` | 移除成员（尽力打断其当前轮次） |
 | `agent_teams_create_task` | 创建任务，支持 `dependencies` 依赖声明与 `assignee` 指派 |
 | `agent_teams_claim_task` | 领取任务（校验依赖；队长可代领，成员只能领自己的/未指派的） |
@@ -67,10 +67,13 @@
     memberProvider: spawn         # 子代理运行后端（spawn / fork），不是 LLM provider
     memberModel: deepseek-v4      # 可选：成员模型覆盖
     memberMaxDepth: 1             # 成员再委派深度上限（0 = 禁止）
+    memberPersonaPlacement: system # system（默认）或 prompt
     maxMembers: 8                 # 团队人数上限
 ```
 
 最终优先级为：成员显式 `provider` + `model` / `model` → `memberModel` → 队长当前路由。思考强度默认继承队长当前值，并在目标 provider/model 上创建前校验；不兼容时成员创建会明确失败。最终生效的 provider/model/思考强度会写入 `team.json`，供状态查询和成员冷恢复使用。
+
+`memberPersonaPlacement: system` 保持原行为：成员协议作为 scoped persona 覆盖部署 persona。`prompt` 将同一份成员协议放进首条用户消息，不发送子 Agent `request.persona`，因此 Anchored Standard、梁神模式等依赖精确首轮系统提示的 preset 可以原样完成轨迹锚定；协议仍随会话历史持久化并参与续聊。
 
 ## 使用协议
 
@@ -80,7 +83,7 @@
 
 - 成员在收到消息（被唤醒）后才行动，没有常驻轮询；队长离线时消息留在邮箱、待队长下次操作时投递。
 - 一个队长同时只能带一个团队（与 Claude Code AgentTeams 一致）。
-- 成员 persona 替换部署默认 persona；成员仍拥有完整工具集（bash/fs/web 等）。
+- `memberPersonaPlacement: system` 会替换部署默认 persona；`prompt` 会保留 preset persona，并把成员协议持久化在首条用户消息中。成员仍拥有完整工具集（bash/fs/web 等）。
 - 团队状态为文件级持久化，多进程同时操作同一团队不保证一致（同一 dsh 进程内已用锁串行化）。
 - 活动面板读磁盘真相（1s 轮询），与会话日志事件流相互独立。
 - 右上角浮层通过 body portal 挂载；宽屏展开时主对话列平滑向左礼让空间，窄屏退回 overlay 模式，左侧导航保持不动。

--- a/scripts/verify.mjs
+++ b/scripts/verify.mjs
@@ -441,6 +441,46 @@ check(
     && spawnMemberRecord.id === 'spawned-member',
 )
 
+let inheritedPersonaStartSpec
+let inheritedPersonaSpawned = false
+try {
+  await spawnMember(
+    {
+      subagents: {
+        getProvider: () => ({
+          prepareContinuable: () => undefined,
+          capabilities: { persona: false, toolFilter: true },
+        }),
+        list: () => ['spawn'],
+        startContinuable: async (spec) => {
+          inheritedPersonaStartSpec = spec
+          return { childId: 'inherited-persona-member', messageId: 'welcome-message' }
+        },
+      },
+    },
+    { provider: 'spawn', maxDepth: 1, personaPlacement: 'prompt' },
+    {
+      withPending: async (_parentId, _label, _selection, operation) => operation(),
+    },
+    overriddenSelection,
+    captain,
+    spawnTeam,
+    { ...spawnMemberRecord, id: '', name: 'anchored-worker' },
+    '.agent-teams',
+    new AbortController().signal,
+  )
+  inheritedPersonaSpawned = true
+} catch {
+  inheritedPersonaSpawned = false
+}
+check(
+  'prompt persona placement preserves the child preset and moves member protocol into the initial message',
+  inheritedPersonaSpawned
+    && inheritedPersonaStartSpec?.request?.persona === undefined
+    && inheritedPersonaStartSpec?.request?.prompt?.[0]?.text.includes('You are anchored-worker')
+    && inheritedPersonaStartSpec?.request?.prompt?.[0]?.text.includes('wait for instructions'),
+)
+
 function descriptorEvent(label, agentProvider = 'descriptor-provider', agentModel = 'descriptor-model') {
   return {
     type: 'subagent/descriptor',

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ import { readFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { collectArchivedTeamsActivity, collectTeamsActivity } from './snapshot.ts'
+import type { MemberPersonaPlacement } from './members.ts'
 
 /**
  * Structural slice of the web server service, compatible with both the
@@ -61,12 +62,14 @@ export interface Config {
    * `<workspace>/<stateDir>/<teamId>/` (default `.agent-teams`).
    */
   stateDir?: string
-  /** `ctx.subagents` provider used to spawn members; must support continuable children and personas (default `spawn`). */
+  /** `ctx.subagents` provider used to spawn members; must support continuable children (default `spawn`). */
   memberProvider?: string
   /** Optional model override applied to every member. */
   memberModel?: string
   /** Member delegation depth cap (default `1`; `0` forbids delegation entirely). */
   memberMaxDepth?: number
+  /** Put the member protocol in a scoped system persona or the initial user prompt (default `system`). */
+  memberPersonaPlacement?: MemberPersonaPlacement
   /** Team size cap in members (default `8`). */
   maxMembers?: number
   /** Prompt-section order for the usage policy (default `117`, after delegation policy). */
@@ -78,6 +81,7 @@ export const Config: z<Config> = z.object({
   memberProvider: z.string().default('spawn'),
   memberModel: z.string(),
   memberMaxDepth: z.natural().default(1),
+  memberPersonaPlacement: z.union(['system', 'prompt'] as const).default('system'),
   maxMembers: z.natural().min(1).default(8),
   promptSectionOrder: z.natural().default(117),
 })
@@ -101,6 +105,7 @@ export function apply(ctx: Context, config: Config): void {
     memberProvider: config.memberProvider ?? 'spawn',
     memberModel: config.memberModel,
     memberMaxDepth: config.memberMaxDepth ?? 1,
+    memberPersonaPlacement: config.memberPersonaPlacement ?? 'system',
     maxMembers: config.maxMembers ?? 8,
   }
 

--- a/src/members.ts
+++ b/src/members.ts
@@ -43,11 +43,16 @@ function brandedSessionId(value: string): SessionId {
 
 /** Runtime knobs for member spawning, resolved from plugin config. */
 export interface MemberRuntimeConfig {
-  /** Registered `ctx.subagents` provider name (must support continuable + persona). */
+  /** Registered `ctx.subagents` provider name (must support continuable children). */
   provider: string
   /** Child delegation depth cap (0 forbids delegation entirely). */
   maxDepth?: number
+  /** Where the member protocol is injected. */
+  personaPlacement: MemberPersonaPlacement
 }
+
+/** How a member receives its role and team protocol. */
+export type MemberPersonaPlacement = 'system' | 'prompt'
 
 /** Durable provider/model/reasoning snapshot for one member. */
 export interface MemberLlmSelection {
@@ -259,9 +264,19 @@ Working rules:
 /**
  * The initial user message delivered when the member is created.
  * @param team - the team the member joined.
+ * @param member - the member record named by a prompt-scoped protocol.
+ * @param stateDir - configured state directory used by the member protocol.
+ * @param placement - whether the protocol lives in the system persona or this message.
  */
-export function memberWelcome(team: TeamState): string {
-  return `You have joined the team "${team.name}" as a member. The captain will send you tasks and messages; wait for instructions. Current team status: ${team.tasks.length} task(s), none assigned to you yet.`
+export function memberWelcome(
+  team: TeamState,
+  member: TeamMember,
+  stateDir: string,
+  placement: MemberPersonaPlacement,
+): string {
+  const welcome = `You have joined the team "${team.name}" as a member. The captain will send you tasks and messages; wait for instructions. Current team status: ${team.tasks.length} task(s), none assigned to you yet.`
+  if (placement === 'system') return welcome
+  return `${memberPersona(team, member, stateDir)}\n\n${welcome}`
 }
 
 /**
@@ -301,7 +316,7 @@ export async function spawnMember(
   if (provider.prepareContinuable === undefined) {
     throw new Error(`agent-teams: provider "${config.provider}" does not support continuable members`)
   }
-  if (!provider.capabilities.persona) {
+  if (config.personaPlacement === 'system' && !provider.capabilities.persona) {
     throw new Error(`agent-teams: provider "${config.provider}" cannot apply a member persona`)
   }
   if (!provider.capabilities.toolFilter) {
@@ -313,9 +328,11 @@ export async function spawnMember(
       provider: config.provider,
       label,
       request: {
-        prompt: [{ type: 'text', text: memberWelcome(team) }],
+        prompt: [{ type: 'text', text: memberWelcome(team, member, stateDir, config.personaPlacement) }],
         parent: captain,
-        persona: memberPersona(team, member, stateDir),
+        ...config.personaPlacement === 'system'
+          ? { persona: memberPersona(team, member, stateDir) }
+          : {},
         toolFilter: { deny: [...MEMBER_DENIED_TOOLS] },
         agentOptions: {
           provider: llmSelection.provider,

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -40,6 +40,7 @@ import {
   memberActivity,
   resolveMemberLlmSelection,
   spawnMember,
+  type MemberPersonaPlacement,
   type MemberRuntimeConfig,
 } from './members.ts'
 import type { TeamMember, TeamState, TeamTask } from './types.ts'
@@ -54,6 +55,8 @@ export interface ToolsConfig {
   memberModel?: string
   /** Member delegation depth cap. */
   memberMaxDepth?: number
+  /** Where each member receives its role and team protocol. */
+  memberPersonaPlacement: MemberPersonaPlacement
   /** Team size cap (members). */
   maxMembers: number
 }
@@ -828,6 +831,7 @@ function memberRuntime(config: ToolsConfig): MemberRuntimeConfig {
   return {
     provider: config.memberProvider,
     maxDepth: config.memberMaxDepth,
+    personaPlacement: config.memberPersonaPlacement,
   }
 }
 


### PR DESCRIPTION
## Summary

- add configurable memberPersonaPlacement with backward-compatible system default
- allow prompt placement to keep the child preset deployment persona unchanged
- persist the full member protocol in the initial user message for prompt mode
- add regression coverage for providers without scoped persona support
- document Anchored Standard and other trajectory-sensitive preset usage

## Verification

- pnpm verify
- pnpm build
- pnpm typecheck
- live DSH parent/worker Trace: identical Anchored Standard first system persona and bash + str_replace_editor bootstrap tools