### PR TITLE
fix: add prepare script so github: installs build lib/

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json && tsc -p tsconfig.client.json && tsdown",
+    "prepare": "npm run build",
     "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.client.json --noEmit",
     "sync:skill": "node scripts/sync-skill.mjs",
     "verify:skill": "node scripts/sync-skill.mjs --check",


### PR DESCRIPTION
Installing via \dsh plugin --profile web add github:NanmiCoder/dsh-agent-teams\ currently **fails to boot**: the package declares \main: lib/index.js\ but git-hosted installs never run \prepublishOnly\, so \lib/\ stays empty and the loader throws \Cannot find module .../lib/index.js\.\n\npnpm runs the **\prepare\** script for git dependencies, so adding \prepare: pnpm build\ makes the GitHub-install path build \lib/\ automatically (devDependencies are all published npm versions - no local dsh checkout needed). The npm-published package is unaffected.