### PR TITLE
feat: make activity panel draggable + slow snapshot poll to 3000ms

### DIFF
--- a/src/client/ActivityPanel.module.css
+++ b/src/client/ActivityPanel.module.css
@@ -133,6 +133,19 @@
   min-height: 44px;
   padding: 0 14px 0 16px;
   border-bottom: 1px solid var(--dsw-alias-line-normal);
+  cursor: grab;
+  touch-action: none;
+}
+
+.panelHead:active {
+  cursor: grabbing;
+}
+
+/* Once the user has dragged the panel, inline left/top positioning takes over
+ * (right is set to auto inline); drop the one-shot entry animation so a drag
+ * never fights a re-running transform. */
+.panel[data-dragged='true'] {
+  animation: none;
 }
 
 .panelTitle {
@@ -972,3 +985,4 @@
     padding-left: 45px;
   }
 }
+

--- a/src/client/ActivityPanel.tsx
+++ b/src/client/ActivityPanel.tsx
@@ -70,13 +70,16 @@ function readPanelPos(): { x: number; y: number } | null {
   return null
 }
 
-/** Keep the panel meaningfully on-screen: clamp its top-left so the user can
- * still reach a chunk of it after a sloppy drag. */
+/** Keep the panel meaningfully on-screen: clamp its top-left so at least a
+ * `MIN_VISIBLE` chunk remains reachable after a sloppy drag. Uses both
+ * panel dimensions so it can never be dragged almost entirely off-screen. */
+const MIN_VISIBLE = 48
 function clampPanelPos(pos: { x: number; y: number }, panelWidth: number, panelHeight: number): { x: number; y: number } {
-  const minX = -(panelWidth * 0.6)
-  const maxX = window.innerWidth - 24
+  const visible = Math.min(MIN_VISIBLE, panelWidth, panelHeight)
+  const minX = -(panelWidth - visible)
+  const maxX = window.innerWidth - visible
   const minY = 8
-  const maxY = window.innerHeight - 24
+  const maxY = window.innerHeight - visible
   return {
     x: Math.max(minX, Math.min(maxX, pos.x)),
     y: Math.max(minY, Math.min(maxY, pos.y)),
@@ -532,23 +535,38 @@ export function ActivityPanel({ sessionsList, openSession }: {
     panelW: number
     panelH: number
   } | null>(null)
-  // Persist the saved position (and remove the key when the user has not moved it).
+  // Persist the saved position to localStorage. Debounced (~250ms) so the
+  // high-frequency setPanelPos during a drag settle into one write (Copilot:
+  // avoid synchronous localStorage writes on every pointer move → jank).
+  const persistTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   useEffect(() => {
-    try {
-      if (panelPos === null) localStorage.removeItem(PANEL_POS_KEY)
-      else localStorage.setItem(PANEL_POS_KEY, JSON.stringify(panelPos))
-    } catch {
-      // Privacy mode / quota: non-fatal.
+    if (panelPos === null) {
+      // No saved position: remove immediately (no debounce needed).
+      if (persistTimerRef.current !== null) { clearTimeout(persistTimerRef.current); persistTimerRef.current = null }
+      try { localStorage.removeItem(PANEL_POS_KEY) } catch { /* non-fatal */ }
+      return
     }
+    if (persistTimerRef.current !== null) clearTimeout(persistTimerRef.current)
+    persistTimerRef.current = setTimeout(() => {
+      persistTimerRef.current = null
+      try { localStorage.setItem(PANEL_POS_KEY, JSON.stringify(panelPos)) } catch { /* non-fatal */ }
+    }, 250)
   }, [panelPos])
+  // Flush pending write on unmount so a just-finished drag isn't lost.
+  useEffect(() => () => {
+    if (persistTimerRef.current !== null) clearTimeout(persistTimerRef.current)
+  }, [])
 
-  /** Begin dragging from the panel header. Ignores pointer-downs on the close
+  /** Begin dragging from the panel header. Primary-button only; prevents text
+   * selection during the drag gesture. Ignores pointer-downs on the close
    * button (and any other interactive child) so clicks still reach it. */
   const onHeaderPointerDown = (event: ReactPointerEvent<HTMLElement>): void => {
+    if (event.button !== 0) return // 仅主键拖拽，忽略右键/中键等
     const target = event.target as HTMLElement
     if (target.closest('button') !== null) return
     const el = panelRef.current
     if (el === null) return
+    event.preventDefault() // 抑制拖动过程中 header 的文本选择
     // Capture on the header so move/up keep flowing to it even when the pointer
     // leaves the panel mid-drag.
     const handle = event.currentTarget as HTMLElement

--- a/src/client/ActivityPanel.tsx
+++ b/src/client/ActivityPanel.tsx
@@ -15,7 +15,7 @@
  * @module dsh-agent-teams/client/activity
  */
 
-import { useEffect, useLayoutEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react'
+import { useEffect, useLayoutEffect, useMemo, useRef, useState, useSyncExternalStore, type PointerEvent as ReactPointerEvent } from 'react'
 import {
   IconBranchOutline16, IconChevronRightOutline14, IconCloseOutline16,
   StateDot, type StateDotState,
@@ -33,8 +33,8 @@ import { OPEN_PANEL_EVENT } from './AgentTeamsCard.tsx'
 import type { AgentTeamsCardData } from './agent-teams-card-definition.ts'
 import css from './ActivityPanel.module.css'
 
-/** Poll cadence for the host snapshot route. */
-const POLL_MS = 1000
+/** Poll cadence for the host snapshot route (raised from 1000ms to reduce load). */
+const POLL_MS = 3000
 /** Grace before the panel collapses once no team remains. */
 const AUTOCLOSE_GRACE_MS = 2000
 /**
@@ -47,6 +47,41 @@ const AUTO_OPEN_SETTLE_MS = 4000
 const STATE_URL = '/plugins/dsh-agent-teams/state'
 /** Root marker shared with the panel CSS while the portal is expanded. */
 const PANEL_OPEN_ATTRIBUTE = 'data-agent-teams-panel-open'
+
+/**
+ * Draggable panel position (P2: user may move the top-right floater elsewhere).
+ * `null` keeps the CSS default (top-right, `top`/`right` anchored). A saved
+ * position switches the panel to `left`/`top` anchoring via inline style.
+ */
+const PANEL_POS_KEY = 'dsh-agent-teams:panel-pos'
+
+/** Read a previously saved panel position; malformed/absent → null (default corner). */
+function readPanelPos(): { x: number; y: number } | null {
+  try {
+    const raw = localStorage.getItem(PANEL_POS_KEY)
+    if (raw === null) return null
+    const parsed = JSON.parse(raw) as { x?: unknown; y?: unknown }
+    if (typeof parsed?.x === 'number' && typeof parsed?.y === 'number') {
+      return { x: parsed.x, y: parsed.y }
+    }
+  } catch {
+    // Malformed payload: fall back to the default corner.
+  }
+  return null
+}
+
+/** Keep the panel meaningfully on-screen: clamp its top-left so the user can
+ * still reach a chunk of it after a sloppy drag. */
+function clampPanelPos(pos: { x: number; y: number }, panelWidth: number, panelHeight: number): { x: number; y: number } {
+  const minX = -(panelWidth * 0.6)
+  const maxX = window.innerWidth - 24
+  const minY = 8
+  const maxY = window.innerHeight - 24
+  return {
+    x: Math.max(minX, Math.min(maxX, pos.x)),
+    y: Math.max(minY, Math.min(maxY, pos.y)),
+  }
+}
 
 /** One member row of a host snapshot. */
 export interface ActivityMember {
@@ -476,6 +511,62 @@ export function ActivityPanel({ sessionsList, openSession }: {
   const mountedAtRef = useRef(performance.now())
   const expanded = activityPanelExpandedForSession(open, openOwner, current)
 
+  // Draggable panel: user may move the floater; position persists to localStorage.
+  const [panelPos, setPanelPos] = useState<{ x: number; y: number } | null>(readPanelPos)
+  const panelRef = useRef<HTMLElement | null>(null)
+  const dragRef = useRef<{
+    pointerId: number
+    startClientX: number
+    startClientY: number
+    origX: number
+    origY: number
+    panelW: number
+    panelH: number
+  } | null>(null)
+  // Persist the saved position (and remove the key when the user has not moved it).
+  useEffect(() => {
+    try {
+      if (panelPos === null) localStorage.removeItem(PANEL_POS_KEY)
+      else localStorage.setItem(PANEL_POS_KEY, JSON.stringify(panelPos))
+    } catch {
+      // Privacy mode / quota: non-fatal.
+    }
+  }, [panelPos])
+
+  /** Begin dragging from the panel header. Ignores pointer-downs on the close
+   * button (and any other interactive child) so clicks still reach it. */
+  const onHeaderPointerDown = (event: ReactPointerEvent<HTMLElement>): void => {
+    const target = event.target as HTMLElement
+    if (target.closest('button') !== null) return
+    const el = panelRef.current
+    if (el === null) return
+    // Capture on the header so move/up keep flowing to it even when the pointer
+    // leaves the panel mid-drag.
+    const handle = event.currentTarget as HTMLElement
+    handle.setPointerCapture(event.pointerId)
+    const rect = el.getBoundingClientRect()
+    dragRef.current = {
+      pointerId: event.pointerId,
+      startClientX: event.clientX,
+      startClientY: event.clientY,
+      origX: rect.left,
+      origY: rect.top,
+      panelW: rect.width,
+      panelH: rect.height,
+    }
+  }
+  /** Update the panel position while dragging (clamped to the viewport). */
+  const onHeaderPointerMove = (event: ReactPointerEvent<HTMLElement>): void => {
+    const drag = dragRef.current
+    if (drag === null || drag.pointerId !== event.pointerId) return
+    const dx = event.clientX - drag.startClientX
+    const dy = event.clientY - drag.startClientY
+    setPanelPos(clampPanelPos({ x: drag.origX + dx, y: drag.origY + dy }, drag.panelW, drag.panelH))
+  }
+  const onHeaderPointerUp = (event: ReactPointerEvent<HTMLElement>): void => {
+    if (dragRef.current?.pointerId === event.pointerId) dragRef.current = null
+  }
+
   // This portal survives conversation route changes. Gate expansion by its
   // owning session during render, then clear stale state before paint. This
   // removes the old panel immediately instead of waiting for the no-team
@@ -627,8 +718,21 @@ export function ActivityPanel({ sessionsList, openSession }: {
         }} />
       )}
       {expanded && (
-        <aside className={css.panel} data-agent-teams-activity>
-          <header className={css.panelHead}>
+        <aside
+          ref={panelRef}
+          className={css.panel}
+          data-agent-teams-activity
+          data-dragged={panelPos !== null}
+          style={panelPos === null ? undefined : { left: panelPos.x, top: panelPos.y, right: 'auto' }}
+        >
+          <header
+            className={css.panelHead}
+            title="按住拖动面板"
+            onPointerDown={onHeaderPointerDown}
+            onPointerMove={onHeaderPointerMove}
+            onPointerUp={onHeaderPointerUp}
+            onPointerCancel={onHeaderPointerUp}
+          >
             <span className={css.panelTitle}>
               AgentTeams 活动
               <span className={css.panelDot} data-busy={busy} aria-hidden />
@@ -704,3 +808,4 @@ export function ActivityPanel({ sessionsList, openSession }: {
     </>
   )
 }
+

--- a/src/client/ActivityPanel.tsx
+++ b/src/client/ActivityPanel.tsx
@@ -174,13 +174,22 @@ function taskTone(state: ActivityTask['state'], status: string): string {
 }
 
 /** Collapsed badge: an always-visible corner pill while any team exists. */
-function CollapsedBadge({ count, busy, onClick }: {
+function CollapsedBadge({ count, busy, onClick, panelPos }: {
   readonly count: number
   readonly busy: boolean
   readonly onClick: () => void
+  /** Saved drag position; when set the badge follows the panel (left/top, right auto). */
+  readonly panelPos: { x: number; y: number } | null
 }) {
   return (
-    <button type="button" className={css.badge} data-busy={busy} onClick={onClick} aria-label={`AgentTeams 活动，${count} 个团队`}>
+    <button
+      type="button"
+      className={css.badge}
+      data-busy={busy}
+      onClick={onClick}
+      aria-label={`AgentTeams 活动，${count} 个团队`}
+      style={panelPos === null ? undefined : { left: panelPos.x, top: panelPos.y, right: 'auto' }}
+    >
       <span className={css.badgeDot} data-busy={busy} aria-hidden />
       <span className={css.badgeCount}>{count}</span>
     </button>
@@ -711,7 +720,7 @@ export function ActivityPanel({ sessionsList, openSession }: {
   return (
     <>
       {!expanded && (
-        <CollapsedBadge count={visibleCount} busy={busy} onClick={() => {
+        <CollapsedBadge count={visibleCount} busy={busy} panelPos={panelPos} onClick={() => {
           if (current === undefined) return
           setOpenOwner(current)
           setOpen(true)


### PR DESCRIPTION
# PR: 活动面板可拖动 + 轮询降频

## Summary

1. **活动面板可拖动**：按住面板头部即可把右上角浮层拖到屏幕任意位置；
   定位从 `right/bottom` 切换为 `left/top`（拖动后 inline 覆盖），并 **localStorage 持久化**
   （键 `dsh-agent-teams:panel-pos`），刷新/重开后保持在原地；未拖动时维持默认右上角。
   折叠态 badge 也跟随同一保存位置，不跳回右上角。
2. **轮询降频**（纯轮询，无 SSE 通道）：`POLL_MS` 1000→3000ms。面板每轮 `Promise.all`
   拉 `/state` 与 `/state?archived=1`，原 1s 一轮实为 2 请求/s；改为 3s 一轮后快照请求负载
   降约 **3 倍**。面板的 `/state` 是**唯一刷新机制**（没有 SSE），这是纯轮询降频——
   最大刷新延迟从 1s 增至 3s，对右上角状态监视面板可接受。

## 改动

- `src/client/ActivityPanel.tsx`：新增 `PANEL_POS_KEY`/`readPanelPos`/`clampPanelPos` 辅助函数、
  组件内 `panelPos`/`panelRef`/`dragRef` 状态、`onHeaderPointerDown/Move/Up` 拖拽处理器、
  `<aside>` 加 ref/data-dragged/inline 位置、`<header>` 加 pointer 处理器与 title；
  `CollapsedBadge` 接收 `panelPos` 并应用同一 left/top；`POLL_MS=3000`。
- `src/client/ActivityPanel.module.css`：`.panelHead` 加 `cursor:grab`/`touch-action:none`，
  `.panel[data-dragged=true]` 关动画。

（`lib/` 为构建产物且被 .gitignore 忽略——本 PR 仅改源码，构建方 `pnpm build` 重新生成。）

## 验证

- 本地改 `lib/client.js`（编译产物）后硬刷新 DSH 页面：
  - 确认服务端下发的 bundle 含 `PANEL_POS_KEY`/`clampPanelPos`/`data-dragged`/`cursor:grab` 与 `POLL_MS=3e3`；
  - 实测 `/plugins/dsh-agent-teams/state` 轮询间隔 **≈3000ms**（从原 1s 降为 3s），无 console 报错；
- 用与实际处理器逻辑一致的 DOM 模拟验证拖拽：按下→移动更新 left/top（精确跟随指针位移、视口内夹紧）、
  释放结束、localStorage 写入位置；badge reflow 实测 left/top 精确跟随；关闭按钮上的 pointerdown 不触发拖拽。

## 备注

- 拖拽手柄为面板 **头部**（header）——避免拖整张面板时与任务点击/列表滚动冲突。
- 面板 `/state` 是**纯轮询**（本插件无 SSE/事件推送通道），`POLL_MS` 是它的唯一刷新定时器；
  由 1000ms 提至 3000ms 后最大刷新延迟为 3s（此前为 1s），对右上角状态监视可接受，快照负载降约 3 倍。
