### PR TITLE
fix(state): harden Windows team.json atomic replace and clean up orphan members

### DIFF
--- a/scripts/verify.mjs
+++ b/scripts/verify.mjs
@@ -10,7 +10,7 @@
  * Usage: node scripts/verify.mjs
  */
 
-import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, readdir, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import {
@@ -62,7 +62,7 @@ console.log('dsh-agent-teams offline verification')
 // loads this plugin, so it must equal the published package name. A mismatch
 // only surfaces after someone installs the package (the row fails to load),
 // never in local link-installed development — hence this pre-publish gate.
-console.log('1/7 packaging contract')
+console.log('1/8 packaging contract')
 const pkg = JSON.parse(await readFile(new URL('../package.json', import.meta.url), 'utf8'))
 const patchText = await readFile(new URL('../cordis.patch.yml', import.meta.url), 'utf8')
 const patchName = patchText
@@ -138,7 +138,7 @@ check(
   'running work should stay visible in both normal and dependency-focus states',
 )
 
-console.log('2/7 pure rules')
+console.log('2/8 pure rules')
 check("sanitizeKey('My Team!') -> 'my-team'", sanitizeKey('My Team!') === 'my-team')
 // #15: an ASCII-only whitelist folded every non-Latin name onto one constant,
 // so distinct members shared a mailbox file and the second one was rejected as
@@ -172,7 +172,7 @@ check('in_progress -> completed allowed', transitionError('in_progress', 'comple
 check('completed -> in_progress denied', transitionError('completed', 'in_progress') !== undefined)
 check('same status is a no-op', transitionError('failed', 'failed') === undefined)
 
-console.log('3/7 dependency gating')
+console.log('3/8 dependency gating')
 const tasks = [
   { id: 't1', status: 'completed' },
   { id: 't2', status: 'pending' },
@@ -182,7 +182,7 @@ check('all-done deps satisfied', unsatisfiedDependencies(tasks, ['t1']).length =
 check('pending dep blocks', unsatisfiedDependencies(tasks, ['t2']).length === 1)
 check('failed dep blocks too', unsatisfiedDependencies(tasks, ['t3']).length === 1)
 
-console.log('4/7 on-disk team flow (temp dir)')
+console.log('4/8 on-disk team flow (temp dir)')
 const stateRoot = await mkdtemp(join(tmpdir(), 'dsh-agent-teams-verify-'))
 try {
   const team = {
@@ -287,7 +287,7 @@ try {
   await rm(stateRoot, { recursive: true, force: true })
 }
 
-console.log('5/7 host visual-state functions (activity panel)')
+console.log('5/8 host visual-state functions (activity panel)')
 const { taskVisualState, taskDepthsById } = await import('../lib/state.js')
 const vtasks = [
   { id: 't1', subject: 'a', status: 'completed', assignee: 'alice', dependencies: [], createdAt: 0, updatedAt: 0 },
@@ -306,7 +306,7 @@ check('t2 depth 1 (longest path)', depths.get('t2') === 1)
 check('t3 depth 2', depths.get('t3') === 2)
 check('missing dep contributes no depth', depths.get('t4') === 0)
 
-console.log('6/7 client relationship projections')
+console.log('6/8 client relationship projections')
 const projectionTasks = [
   { id: 't4', dependencies: ['t2'], depth: 2 },
   { id: 't1', dependencies: [], depth: 0 },
@@ -394,7 +394,7 @@ check(
   steerCaptainReport({ steer: () => { throw new Error('offline') } }, 'alice', 'finished t1') === false,
 )
 
-console.log('7/7 member model selection and continuation restore')
+console.log('7/8 member model selection and continuation restore')
 const captain = {
   id: 'captain-session',
   options: { provider: 'birth-provider', model: 'birth-model' },
@@ -616,6 +616,215 @@ try {
   disposeCold()
 } finally {
   await rm(restoreWorkspace, { recursive: true, force: true })
+}
+
+console.log('8/8 state-file atomic write hardening (Windows EPERM fallback)')
+// The durable state files (team.json, mailboxes, retired index) are replaced
+// through `atomicWriteText` = write-temp + rename. On Windows a rename over an
+// existing target throws EPERM while another process holds it open without
+// FILE_SHARE_DELETE; the hardened path retries the rename a few times and then
+// degrades to a direct overwrite (content-equivalent because the temp file was
+// fully written). These checks pin that behavior through the injectable seam
+// and, on Windows, against a real cross-process handle lock.
+const atomicStateRoot = await mkdtemp(join(tmpdir(), 'dsh-agent-teams-atomic-'))
+try {
+  const {
+    replaceFileAtomicOrDirect,
+    writeTeam,
+  } = await import('../lib/state.js')
+  const epermError = () => Object.assign(
+    new Error("EPERM: operation not permitted, rename '.../team.json.tmp' -> '.../team.json'"),
+    { code: 'EPERM' },
+  )
+
+  let renameCalls = 0
+  let fallbackWrites = 0
+  let fallbackRemovals = 0
+  let fallbackContent = ''
+  const fallbackTarget = join(atomicStateRoot, 'forced', 'team.json')
+  await replaceFileAtomicOrDirect('forced.tmp', fallbackTarget, '{"fallback":1}', {
+    rename: async () => { renameCalls += 1; throw epermError() },
+    writeFile: async (_file, content) => { fallbackWrites += 1; fallbackContent = content },
+    remove: async () => { fallbackRemovals += 1 },
+  }, { retryDelayMs: 1 })
+  check(
+    'persistent EPERM exhausts the rename retries (1 initial + 3 retries)',
+    renameCalls === 4,
+    `renameCalls = ${renameCalls}`,
+  )
+  check(
+    'persistent EPERM falls back to a direct overwrite of the target',
+    fallbackWrites === 1 && fallbackContent === '{"fallback":1}',
+    `fallbackWrites = ${fallbackWrites}`,
+  )
+  check('the temp file is removed after the fallback write', fallbackRemovals === 1)
+
+  let transientCalls = 0
+  let transientWrites = 0
+  await replaceFileAtomicOrDirect('transient.tmp', join(atomicStateRoot, 'transient', 'team.json'), '{"retried":2}', {
+    rename: async () => {
+      transientCalls += 1
+      if (transientCalls <= 2) throw epermError()
+    },
+    writeFile: async (file, content) => { transientWrites += 1; await writeFile(file, content) },
+    remove: async () => undefined,
+  }, { retryDelayMs: 1 })
+  check(
+    'a transient EPERM recovers via rename retries without the fallback',
+    transientCalls === 3 && transientWrites === 0,
+    `renameCalls = ${transientCalls}, fallbackWrites = ${transientWrites}`,
+  )
+
+  let aggregateThrown = false
+  let dualRemovals = 0
+  try {
+    await replaceFileAtomicOrDirect('dual.tmp', join(atomicStateRoot, 'dual', 'team.json'), 'x', {
+      rename: async () => { throw epermError() },
+      writeFile: async () => { throw Object.assign(new Error('EACCES: permission denied'), { code: 'EACCES' }) },
+      remove: async () => { dualRemovals += 1 },
+    }, { retryDelayMs: 1 })
+  } catch (error) {
+    aggregateThrown = error instanceof AggregateError
+  }
+  check('failure of both the atomic and the direct path raises AggregateError', aggregateThrown)
+  check('the temp file is removed even after a dual failure', dualRemovals === 1)
+
+  if (process.platform === 'win32') {
+    // Real cross-process lock: hold team.json with FileShare.ReadWrite (no
+    // FILE_SHARE_DELETE) from a child .NET handle, then verify the public
+    // write path still persists through the direct-write fallback.
+    const lockedTeam = {
+      name: 'Locked Team',
+      id: 'locked-team',
+      captainSessionId: 'sess-lock',
+      createdAt: Date.now(),
+      members: [],
+      tasks: [],
+      taskSeq: 0,
+    }
+    await createTeamDir(atomicStateRoot, lockedTeam)
+    const lockedJson = join(atomicStateRoot, lockedTeam.id, 'team.json')
+    const { spawn } = await import('node:child_process')
+    const holder = spawn(
+      'powershell.exe',
+      ['-NoProfile', '-NonInteractive', '-Command',
+        `$f = '${lockedJson.replaceAll("'", "''")}';
+         $s = [System.IO.File]::Open($f, [IO.FileMode]::Open, [IO.FileAccess]::ReadWrite, [IO.FileShare]::ReadWrite);
+         [Console]::Out.WriteLine('HELD'); [Console]::Out.Flush();
+         Start-Sleep -Seconds 45; $s.Dispose()`],
+      { stdio: ['ignore', 'pipe', 'inherit'] },
+    )
+    const held = await new Promise((resolve, reject) => {
+      let buffer = ''
+      const onData = (chunk) => {
+        buffer += chunk.toString()
+        if (buffer.includes('HELD')) { cleanup(); resolve(true) }
+      }
+      const onExit = () => { cleanup(); reject(new Error('lock holder exited before arming')) }
+      const timer = setTimeout(() => {
+        cleanup()
+        reject(new Error('timed out waiting for the lock holder'))
+      }, 15_000)
+      function cleanup() {
+        clearTimeout(timer)
+        holder.stdout.off('data', onData)
+        holder.off('exit', onExit)
+      }
+      holder.stdout.on('data', onData)
+      holder.on('exit', onExit)
+    })
+    try {
+      if (held) {
+        lockedTeam.members.push({ id: 'sess-new', name: 'member', joinedAt: Date.now(), status: 'idle' })
+        await writeTeam(atomicStateRoot, lockedTeam)
+        const persisted = JSON.parse(await readFile(lockedJson, 'utf8'))
+        const leftovers = (await readdir(join(atomicStateRoot, lockedTeam.id))).filter(name => name.endsWith('.tmp'))
+        check(
+          'writeTeam survives a real Windows lock without FILE_SHARE_DELETE',
+          persisted.members.length === 1 && leftovers.length === 0,
+          `members = ${persisted.members.length}, tmp leftovers = ${leftovers.join(', ') || 'none'}`,
+        )
+      }
+      // Archive moves the whole team directory with `rename(source, target)`.
+      // The same Windows delete-sharing EPERM applies when a file below the
+      // directory is momentarily locked, so it retries the rename. A short
+      // (≈150 ms) lock falls inside the retry window and must not abort the
+      // archive.
+      const { archiveTeamDir } = await import('../lib/state.js')
+      const transientTeam = {
+        name: 'Transient Lock Team',
+        id: 'transient-lock',
+        captainSessionId: 'sess-transient',
+        createdAt: Date.now(),
+        members: [],
+        tasks: [],
+        taskSeq: 0,
+      }
+      await createTeamDir(atomicStateRoot, transientTeam)
+      const transientJson = join(atomicStateRoot, transientTeam.id, 'team.json')
+      const flasher = spawn(
+        'powershell.exe',
+        ['-NoProfile', '-NonInteractive', '-Command',
+          `$f = '${transientJson.replaceAll("'", "''")}';
+           $s = [System.IO.File]::Open($f, [IO.FileMode]::Open, [IO.FileAccess]::ReadWrite, [IO.FileShare]::ReadWrite);
+           [Console]::Out.WriteLine('HELD_T'); [Console]::Out.Flush();
+           Start-Sleep -Milliseconds 140; $s.Dispose()`],
+        { stdio: ['ignore', 'pipe', 'inherit'] },
+      )
+      const flashed = await new Promise((resolve, reject) => {
+        let buffer = ''
+        const onData = (chunk) => {
+          buffer += chunk.toString()
+          if (buffer.includes('HELD_T')) { cleanup(); resolve(true) }
+        }
+        const onExit = () => { cleanup(); reject(new Error('transient holder exited before arming')) }
+        const timer = setTimeout(() => {
+          cleanup()
+          reject(new Error('timed out waiting for the transient lock holder'))
+        }, 10_000)
+        function cleanup() {
+          clearTimeout(timer)
+          flasher.stdout.off('data', onData)
+          flasher.off('exit', onExit)
+        }
+        flasher.stdout.on('data', onData)
+        flasher.on('exit', onExit)
+      })
+      try {
+        // The flasher releases after ~140 ms; archiveTeamDir retries the
+        // rename across that window, so archiving must still succeed.
+        await archiveTeamDir(atomicStateRoot, transientTeam.id)
+        const archived = await readFile(join(atomicStateRoot, 'archive', transientTeam.id, 'team.json'), 'utf8')
+        check(
+          'archiveTeamDir survives a transient Windows directory lock via rename retries',
+          flashed && JSON.parse(archived).id === transientTeam.id,
+        )
+      } catch (error) {
+        check(
+          'archiveTeamDir survives a transient Windows directory lock via rename retries',
+          false,
+          String(error),
+        )
+      } finally {
+        flasher.kill()
+      }
+    } finally {
+      holder.kill()
+      if (holder.exitCode === null && holder.signalCode === null) {
+        await new Promise((resolve) => {
+          const timer = setTimeout(resolve, 5_000)
+          holder.once('exit', () => { clearTimeout(timer); resolve() })
+        })
+      }
+    }
+  } else {
+    check('real Windows lock integration skipped on this platform', true)
+  }
+} finally {
+  await rm(atomicStateRoot, { recursive: true, force: true }).catch(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 500))
+    await rm(atomicStateRoot, { recursive: true, force: true })
+  })
 }
 
 if (failures > 0) {

--- a/src/state.ts
+++ b/src/state.ts
@@ -505,16 +505,112 @@ function stripLeadingBom(value: string): string {
   return value.charCodeAt(0) === 0xFEFF ? value.slice(1) : value
 }
 
-/** Atomically replace one UTF-8 state file from a same-directory temp file. */
+/** Rename attempts before falling back to a direct overwrite. */
+const ATOMIC_RENAME_RETRIES = 3
+/** Pause between rename attempts, giving a briefly-locking owner time to finish. */
+const ATOMIC_RENAME_RETRY_DELAY_MS = 50
+/**
+ * Rename error codes worth retrying before the direct-write fallback. On
+ * Windows, replacing an existing file whose target is momentarily held open
+ * without FILE_SHARE_DELETE surfaces as EPERM (or EACCES/EBUSY variants);
+ * EEXIST/ENOTEMPTY cover other "target busy" edge shapes.
+ */
+const RETRYABLE_RENAME_CODES = new Set(['EPERM', 'EACCES', 'EBUSY', 'EEXIST', 'ENOTEMPTY'])
+
+function isRetryableRenameError(error: unknown): boolean {
+  return error instanceof Error
+    && 'code' in error
+    && RETRYABLE_RENAME_CODES.has((error as NodeJS.ErrnoException).code ?? '')
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+/** Filesystem primitives used by {@link replaceFileAtomicOrDirect}; injectable for tests. */
+export interface AtomicReplacePrimitives {
+  rename: (from: string, to: string) => Promise<void>
+  writeFile: (file: string, content: string) => Promise<void>
+  remove: (file: string) => Promise<void>
+}
+
+/** Tuning knobs for {@link replaceFileAtomicOrDirect} (defaults match production). */
+export interface AtomicReplaceOptions {
+  /** Rename attempts before the direct-write fallback (default 3). */
+  retries?: number
+  /** Delay between rename attempts in ms (default 50). */
+  retryDelayMs?: number
+}
+
+/**
+ * Replace `file` with `content`, preferring an atomic same-directory rename of
+ * an already-written temp file.
+ *
+ * On Windows, `rename(tmp, file)` over an existing target throws EPERM while
+ * any other process keeps the target open without FILE_SHARE_DELETE (editors,
+ * indexers, antivirus scans, preview panes). By that point the payload has
+ * already been fully written to the temp file, so a direct overwrite of the
+ * target is a content-equivalent degraded path: retry the rename a few times
+ * (transient locks clear quickly), then write the target in place. Every path
+ * removes the temp file; when both the atomic rename and the direct write
+ * fail, the combined error surfaces as an {@link AggregateError}.
+ *
+ * @returns nothing once the file has been replaced by one of the two paths.
+ */
+export async function replaceFileAtomicOrDirect(
+  temporary: string,
+  file: string,
+  content: string,
+  primitives: AtomicReplacePrimitives,
+  options: AtomicReplaceOptions = {},
+): Promise<void> {
+  const retries = options.retries ?? ATOMIC_RENAME_RETRIES
+  const retryDelayMs = options.retryDelayMs ?? ATOMIC_RENAME_RETRY_DELAY_MS
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      await primitives.rename(temporary, file)
+      return
+    } catch (error: unknown) {
+      if (isRetryableRenameError(error) && attempt < retries) {
+        await sleep(retryDelayMs)
+        continue
+      }
+      let fallbackError: unknown
+      try {
+        await primitives.writeFile(file, content)
+      } catch (writeError: unknown) {
+        fallbackError = writeError
+      }
+      await primitives.remove(temporary).catch(() => undefined)
+      if (fallbackError !== undefined) {
+        throw new AggregateError(
+          [error, fallbackError],
+          `failed to replace "${file}" atomically (${String(error)}) or by direct write (${String(fallbackError)})`,
+        )
+      }
+      return
+    }
+  }
+}
+
+/**
+ * Atomically replace one UTF-8 state file from a same-directory temp file,
+ * degrading to a direct overwrite when the atomic rename cannot proceed
+ * (see {@link replaceFileAtomicOrDirect} for the Windows EPERM rationale).
+ */
 async function atomicWriteText(file: string, content: string): Promise<void> {
   const temporary = `${file}.${process.pid}.${randomUUID()}.tmp`
   try {
     await writeFile(temporary, content, { encoding: 'utf8', flag: 'wx' })
-    await rename(temporary, file)
   } catch (error: unknown) {
     await rm(temporary, { force: true }).catch(() => undefined)
     throw error
   }
+  await replaceFileAtomicOrDirect(temporary, file, content, {
+    rename: (from, to) => rename(from, to),
+    writeFile: (target, payload) => writeFile(target, payload, 'utf8'),
+    remove: (path) => rm(path, { force: true }),
+  })
 }
 
 /** Whether a parsed JSON value is a plain record. */
@@ -630,6 +726,30 @@ export async function removeTeamDir(stateRoot: string, teamId: string): Promise<
 }
 
 /**
+ * `rename` with the same transient retry policy as the state-file atomic
+ * write, for paths (like archiving a whole team directory) where there is no
+ * content-equivalent direct-write degradation on Windows. A short-lived
+ * delete-sharing lock on any file below the renamed path is retried a few
+ * times before the error propagates.
+ * @param from - source path.
+ * @param to - destination path.
+ */
+async function renameWithRetry(from: string, to: string): Promise<void> {
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      await rename(from, to)
+      return
+    } catch (error: unknown) {
+      if (isRetryableRenameError(error) && attempt < ATOMIC_RENAME_RETRIES) {
+        await sleep(ATOMIC_RENAME_RETRY_DELAY_MS)
+        continue
+      }
+      throw error
+    }
+  }
+}
+
+/**
  * Archive a team instead of deleting it: the whole directory (team.json with
  * tasks and dependency graph, plus the mailboxes) moves under
  * `<stateRoot>/archive/<teamId>/` so later sessions can review how tasks were
@@ -646,20 +766,25 @@ export async function archiveTeamDir(stateRoot: string, teamId: string): Promise
   const previous = join(archiveRoot, `.${teamId}.previous-${randomUUID()}`)
   let displaced = false
   try {
-    await rename(target, previous)
+    // The same Windows EPERM-on-rename applies at the directory boundary: a
+    // delete-sharing violation on any file below `target` blocks the move, so
+    // retry the transient-lock case before giving up.
+    await renameWithRetry(target, previous)
     displaced = true
   } catch (error: unknown) {
+    // Only ENOENT means there was nothing to displace; any other failure
+    // (including a persistent EPERM lock) surfaces to the caller.
     if (!(error instanceof Error && 'code' in error && (error as NodeJS.ErrnoException).code === 'ENOENT')) {
       throw error
     }
   }
 
   try {
-    await rename(source, target)
+    await renameWithRetry(source, target)
   } catch (error: unknown) {
     if (displaced) {
       try {
-        await rename(previous, target)
+        await renameWithRetry(previous, target)
       } catch (restoreError: unknown) {
         throw new AggregateError(
           [error, restoreError],

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -362,7 +362,18 @@ export function registerAgentTeamsTools(ctx: Context, config: ToolsConfig): void
           exec.signal,
         )
         fresh.members.push(member)
-        await writeTeam(stateRoot, fresh)
+        try {
+          await writeTeam(stateRoot, fresh)
+        } catch (error: unknown) {
+          // The continuable child is already live, but the durable team record
+          // never saw it. Retire the orphan so it disappears from subagent
+          // listings and cannot be resumed, then surface the write failure.
+          if (member.id !== '') {
+            await recordRetiredMemberIds(stateRoot, [member.id]).catch(() => undefined)
+            interruptMember(ctx, captain, member.id)
+          }
+          throw error
+        }
         appendTeamEvent(ctx, captainSessionOf(ctx, fresh.captainSessionId, captain.session), 'agent-teams/member-added', {
           teamId: fresh.id,
           memberId: member.id,


### PR DESCRIPTION
### 摘要

修复 Windows 上团队状态文件（`team.json`、mailbox、retired 索引）原子替换失败的 EPERM，并清理 `add_member` 在持久化失败时遗留的孤儿成员子代理。对应 issue #39。

### 根因

`src/state.ts` 的 `atomicWriteText` 是「写同目录临时文件 → `rename(tmp, file)`」的单发原子替换，**无重试、无降级**。在 Windows 上，当目标文件被其他进程句柄以不含 `FILE_SHARE_DELETE` 的方式（编辑器、索引器、杀毒扫描、预览面板等）打开时，`fs.rename` 抛 EPERM：

```
EPERM: operation not permitted, rename '.../team.json.<pid>.<uuid>.tmp' -> '.../team.json'
```

此时临时文件已完整写入，直接覆盖目标语义上是等价的，但当前实现选择直接抛错。

### 复现（Windows 实机）

用另一个句柄以 `FileShare.ReadWrite`（无 `FILE_SHARE_DELETE`）锁住 `team.json` 后执行相同原子替换：

| 操作 | 结果 |
| --- | --- |
| `rename(tmp, team.json)`（目标被锁） | `EPERM: operation not permitted, rename ...` |
| `writeFile(team.json, ...)` 直接覆盖同一目标 | 成功 |
| 句柄释放后再次 `rename` | 成功 |

### 改动

1. **`src/state.ts` — `atomicWriteText` 加固**（核心）：
   - 保留「写临时文件 + rename」原子路径为首选；
   - `rename` 抛 EPERM/EACCES/EBUSY/EEXIST/ENOTEMPTY 时**重试 3 次、50ms 退避**（服务瞬态锁）；
   - 仍失败则**降级为直接写目标文件**（临时文件内容已完整，等价覆盖）；直写也失败时抛 `AggregateError`（含两个原因）；
   - 所有路径都清理临时文件。
   - 抽出可注入的 `replaceFileAtomicOrDirect` 单元便于测试。
   - **同路径补充**：`archiveTeamDir`（关闭团队时把整个团队目录 `rename` 到 `archive/`）在源目录内含被锁文件时同样 EPERM，因其无「直接覆盖」降级方案，为其目录 rename 增加同策略的 `renameWithRetry` 瞬态重试。

2. **`src/tools.ts` — `add_member` 孤儿成员**：`spawnMember` 之后 `writeTeam` 失败时，不再静默遗留已 spawn 但未持久化的成员——将刚生成的成员会话记入 retired 名单并中断，再向上抛错，避免无主子会话残留。

### 测试

- `src/state.ts`：新增可注入重试/降级逻辑（`replaceFileAtomicOrDirect`）与直达 archive 的 `renameWithRetry`。
- `scripts/verify.mjs` 新增第 8 段覆盖：
  - 持续 EPERM 耗尽重试后走直写降级（内容正确、temp 清理）；
  - 瞬态 EPERM 经重试后不降级即恢复；
  - rename + 直写双失败抛 `AggregateError` 并清理 temp；
  - **Windows 实机**：真实 `FileShare.ReadWrite` 跨进程锁下 `writeTeam` 仍能持久化成功；
  - **Windows 实机**：瞬态目录锁下 `archiveTeamDir` 经重试仍能归档。

### 验证

- `pnpm typecheck`（host + client 双 program）0 错误
- `pnpm build`（lib + client bundle）通过
- `pnpm verify`（verify + lifecycle + stress + skill mirror）全部通过
- Windows 真机冒烟：patch 库应用后，`team.json` 被无 `FILE_SHARE_DELETE` 句柄锁住时，宿主真实 `agent_teams_create_task` 成功落盘且无 `.tmp` 残留；长锁下 delete 明确报 EPERM（超出瞬态窗，符合预期），释放后 delete 成功归档。

### 行为变更说明

- 持续 EPERM 锁下：文件替换从「必然抛错」变为「重试后降级直写成功」，显著提升 Windows 稳定性；
- 完全无法写入（如只读介质 + rename 被拒）时仍会抛 `AggregateError`，不会静默丢数据。
