### PR TITLE
Fix grammar issue in release-notes/v0.1.11.md: nonstandard_adjective_addressed

### DIFF
--- a/release-notes/v0.1.11.md
+++ b/release-notes/v0.1.11.md
@@ -7,7 +7,7 @@ This release restores AgentTeams activity and member history after a DeepSeek Ha
 - **Cold-start activity recovery**: selecting a captain session now performs a lightweight live and archived team discovery pass, so older sessions without an AgentTeams conversation card restore their activity panel after restart.
 - **Reliable member activity**: live `running / idle / ready` state is resolved from the durable team roster and Agent registry instead of depending on the versioned `listChildren()` projection shape.
 - **Persistent member history**: retired AgentTeams members remain discoverable in the Harness subagent catalog for transcript review while direct follow-up remains blocked.
-- **rc.8 transcript navigation**: activity-panel and conversation-card member links refresh the parent catalog and use addressed `openSubagent()` navigation, with a fallback for older Harness runtimes.
+- **rc.8 transcript navigation**: activity-panel and conversation-card member links refresh the parent catalog and use `openSubagent()` navigation with parent-child addressing, with a fallback for older Harness runtimes.
 
 ## Verification
 


### PR DESCRIPTION
## Summary

This PR fixes a grammar issue in `release-notes/v0.1.11.md` (line 10).

## Problem

The adjective 'addressed' is used in a non-standard and confusing way to describe the navigation method. The intended meaning (per the Chinese version: '带父子地址的' = 'with parent-child addressing') is that `openSubagent()` is called with addressing information that links parent and child. 'Addressed navigation' is not a recognized English technical term and obscures the meaning for readers.

The problematic text:

```markdown
use addressed `openSubagent()` navigation
```

## Fix

Replaced with:

```markdown
use `openSubagent()` navigation with parent-child addressing
```

## Type of Change

- [x] Documentation fix (grammar, spelling, logical error)
- [ ] Code change
- [ ] Breaking change

## Checklist

- [x] Documentation files only
- [x] No code changes
- [x] Fix verified against original text