### PR TITLE
fix: align module export name with package name (@nanmicoder/dsh-agent-teams)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -52,7 +52,7 @@ const WEB_SERVER_KEYS = ['webServer', 'httpServer'] as const
 /** Workspace registry service key candidates, newest first. */
 const WORKSPACE_KEYS = ['workspaceRegistry', 'workspace'] as const
 
-export const name = 'agent-teams'
+export const name = '@nanmicoder/dsh-agent-teams'
 export const inject = ['tools', 'llm', 'subagents', 'systemPrompt', 'agents']
 
 /** Plugin configuration. */


### PR DESCRIPTION
Resolves #54 — the module-exported plugin name was `agent-teams` while `package.json` name is `@nanmicoder/dsh-agent-teams`. The dsh plugin contract requires module-exported `name` to equal `package.json` name (same identity rule as the bundle patch insert `name` / `__ModuleLoader__.load` id); the mismatch trips `dsh plugin check` and any future plugin-name-keyed reference (patch targeting, telemetry, session attribution) would silently miss.

## 变更
`src/index.ts` — `export const name = '@nanmicoder/dsh-agent-teams'`（1 行）。`lib/types/index.d.ts` 与发布产物随构建生成，无需手改；`cordis.patch.yml` 的 insert `name` 已是包名，loader id `agent-teams` 保持不动。

## 验证
- `pnpm build` 通过，构建产物导出名已为 `@nanmicoder/dsh-agent-teams`。
- `pnpm verify`：185 项 PASS；1 项既有失败（`archiveTeamDir` 目录改名重试，Windows 环境瞬时锁用例），在干净 upstream/main 上同样复现，与本改动无关。
- 无测试断言旧名，无内部引用依赖导出名取值。