### PR TITLE
test: cover rate-limit retry storm regression (#66)

### DIFF
--- a/scripts/lifecycle-verify.mjs
+++ b/scripts/lifecycle-verify.mjs
@@ -262,17 +262,20 @@ try {
   // parked attempt from a cold process restart.
   liveAgents.delete(alpha.id)
   const deliveriesBeforeParkedKicks = deliveries.length
-  await Promise.all([
-    call('agent_teams_status', {}),
-    call('agent_teams_status', {}),
-    call('agent_teams_status', {}),
-  ])
+  const parkedAttemptBeforeRateLimitRecovery = await task(t1.task_id)
+  // Model the provider-facing failure boundary from #66: the member's turn
+  // has ended after a rate-limit response, but its durable task capability is
+  // still open. Repeated scheduler/status kicks must park that capability
+  // instead of minting a fresh attempt and inference request each time.
+  for (let kick = 0; kick < 20; kick += 1) {
+    await call('agent_teams_status', {})
+  }
   await new Promise(resolve => setTimeout(resolve, 20))
   const parkedAlpha = await task(t1.task_id)
-  check('resident idle owner keeps its open attempt across repeated scheduler kicks',
+  check('rate-limited idle owner does not enter an unbounded retry loop (#66)',
     parkedAlpha?.status === 'in_progress'
-      && parkedAlpha.attempt === alphaClaim.attempt
-      && parkedAlpha.attemptId === alphaClaim.attempt_id
+      && parkedAlpha.attempt === parkedAttemptBeforeRateLimitRecovery?.attempt
+      && parkedAlpha.attemptId === parkedAttemptBeforeRateLimitRecovery?.attemptId
       && deliveries.length === deliveriesBeforeParkedKicks)
   liveAgents.set(alpha.id, alpha)
 


### PR DESCRIPTION
## Summary

- add a deterministic lifecycle regression covering the rate-limit retry-storm scenario reported in #66
- exercise repeated scheduler kicks after a member becomes idle with an open task capability
- assert that the existing parked-attempt behavior preserves the attempt id and emits no additional delivery

## Scope

This PR intentionally adds verification coverage only. The scheduler behavior under test was introduced by the existing parked-attempt recovery fix; this change makes the #66 invariant explicit in the lifecycle verification suite without introducing a second retry policy.

## Test plan

- `bun run build`
- `node scripts/lifecycle-verify.mjs`

Closes #66
