### PR TITLE
feat: add team history controls

### DIFF
--- a/scripts/lifecycle-verify.mjs
+++ b/scripts/lifecycle-verify.mjs
@@ -511,6 +511,27 @@ try {
       && profileStatus.tasks.some(item => item.seed_id === 'implement'))
   await call('agent_teams_delete', {})
 
+  // Preset staged team must not spawn members before explicit approval
+  const deliveriesBeforeStagedProfile = deliveries.length
+  const createdStagedProfile = await call('agent_teams_create', {
+    name: 'Staged Preset Demo',
+    description: 'preset plan requiring approval',
+    profile: 'demo-delivery',
+    approval: 'required',
+  })
+  const stagedPresetTeam = await readTeam(stateRoot, 'staged-preset-demo')
+  check('preset staged does not spawn members or dispatch tasks before approval',
+    createdStagedProfile.profile === 'demo-delivery'
+      && createdStagedProfile.phase === 'staged'
+      && createdStagedProfile.members?.length === 2
+      && createdStagedProfile.members.every(member => member.member_id === '')
+      && stagedPresetTeam?.phase === 'staged'
+      && stagedPresetTeam.members.every(member => member.id === '')
+      && stagedPresetTeam.tasks.length === 2
+      && stagedPresetTeam.tasks.every(task => task.status === 'pending')
+      && deliveries.length === deliveriesBeforeStagedProfile)
+  await agentTeamsRuntime.discardStagedTeam(captain, 'staged-preset-demo')
+
   const deliveriesBeforeDiscard = deliveries.length
   const captainCancelsBeforeDiscard = captain.cancelCount ?? 0
   const captainInjectionsBeforeDiscard = captain.injections.length

--- a/scripts/verify.mjs
+++ b/scripts/verify.mjs
@@ -493,6 +493,23 @@ check(
     && !agentTeamsCardSource.includes('fetch('),
   'the global panel must recover cardless sessions without duplicate card pollers',
 )
+check(
+  'activity panel exposes archive, hide, restore, and purge controls',
+  activityPanelSource.includes("t('team.archive')")
+    && activityPanelSource.includes("t('archive.hide')")
+    && activityPanelSource.includes("t('archive.restore')")
+    && activityPanelSource.includes("t('archive.purge')")
+    && hostSource.includes("path: '/plugins/dsh-agent-teams/team-action'")
+    && hostSource.includes("action === 'archive'")
+    && hostSource.includes("action === 'purge'"),
+)
+check(
+  'historic controls wrap below the summary without horizontal panel overflow',
+  activityPanelSource.includes('className={css.teamSummary}')
+    && activityPanelSource.includes('className={css.teamActionRow}')
+    && activityPanelCss.includes('.teamActions { display: flex; flex-wrap: wrap;')
+    && activityPanelCss.includes('overflow-x: hidden'),
+)
 
 console.log('2/8 pure rules')
 check("sanitizeKey('My Team!') -> 'my-team'", sanitizeKey('My Team!') === 'my-team')
@@ -730,6 +747,52 @@ try {
   check('archive keeps team.json readable', (await readArchivedTeam(stateRoot, archiveTeam.id))?.id === archiveTeam.id)
   check('archive lists the team id', (await listArchivedTeamIds(stateRoot)).includes(archiveTeam.id))
   check('archive dir skips live readTeam', await readTeam(stateRoot, 'archive') === undefined)
+
+  // Verification of archive rollback & retired member ids rollback
+  const rollbackTeam = {
+    ...team,
+    id: sanitizeKey('Rollback Team'),
+    members: [{ id: 'subagent-rollback-1', name: 'worker', status: 'idle', role: 'test', provider: 'p', model: 'm', joinedAt: Date.now() }],
+  }
+  await createTeamDir(stateRoot, rollbackTeam)
+  const { readRetiredMemberIds, recordRetiredMemberIds, unrecordRetiredMemberIds } = await import('../lib/state.js')
+  const initialRetired = await readRetiredMemberIds(stateRoot)
+  const newlyRetired = ['subagent-rollback-1']
+  await recordRetiredMemberIds(stateRoot, newlyRetired)
+  check('newly retired members recorded before archive', (await readRetiredMemberIds(stateRoot)).has('subagent-rollback-1'))
+  // Simulate an archive failure and exercise rollback compensation
+  await unrecordRetiredMemberIds(stateRoot, newlyRetired)
+  const rolledBackRetired = await readRetiredMemberIds(stateRoot)
+  check('archive failure rollback unrecords retired members', !rolledBackRetired.has('subagent-rollback-1') && rolledBackRetired.size === initialRetired.size)
+  await removeTeamDir(stateRoot, rollbackTeam.id)
+
+  // Verification of generation isolation for same-name teams
+  const genTeam1 = { ...team, id: sanitizeKey('Gen Team'), createdAt: 1000 }
+  const genTeam2 = { ...team, id: sanitizeKey('Gen Team'), createdAt: 2000 }
+  await createTeamDir(stateRoot, genTeam1)
+  const { assembleTeamSnapshot } = await import('../lib/snapshot.js')
+  const dummyCtx = { agents: new Map(), logger: { warn: () => {} } }
+  const genSnapshot1 = await assembleTeamSnapshot(dummyCtx, stateRoot, '/workspace', genTeam1, { historic: true })
+  await archiveTeamDir(stateRoot, genTeam1.id)
+  await createTeamDir(stateRoot, genTeam2)
+  const genSnapshot2 = await assembleTeamSnapshot(dummyCtx, stateRoot, '/workspace', genTeam2, { historic: true })
+  check('same-name different generation teams have isolated generationId snapshots',
+    genSnapshot1.generationId === '1000'
+      && genSnapshot2.generationId === '2000'
+      && genSnapshot1.generationId !== genSnapshot2.generationId)
+  await removeTeamDir(stateRoot, genTeam2.id)
+
+  // Verification of purge restart persistence
+  const { recordPurgedTeam, readPurgedTeams, clearPurgedTeam } = await import('../lib/state.js')
+  const purgeIdentity = { captainSessionId: 'sess-captain', teamId: 'purged-target', generationId: '9999' }
+  await recordPurgedTeam(stateRoot, purgeIdentity)
+  const purgedBefore = await readPurgedTeams(stateRoot)
+  check('purge records persistent identity', purgedBefore.some(e => e.teamId === 'purged-target' && e.generationId === '9999'))
+  // Read back anew (simulating service restart reading from disk)
+  const purgedAfterRestart = await readPurgedTeams(stateRoot)
+  check('purge identity survives restart read from disk', purgedAfterRestart.some(e => e.teamId === 'purged-target' && e.generationId === '9999'))
+  await clearPurgedTeam(stateRoot, purgeIdentity)
+  check('purge identity can be cleared', (await readPurgedTeams(stateRoot)).every(e => e.teamId !== 'purged-target'))
 } finally {
   await rm(stateRoot, { recursive: true, force: true })
 }

--- a/src/client/ActivityPanel.module.css
+++ b/src/client/ActivityPanel.module.css
@@ -292,6 +292,7 @@
   flex-direction: column;
   min-height: 0;
   overflow-y: auto;
+  overflow-x: hidden;
   overscroll-behavior: contain;
   scrollbar-color: color-mix(in srgb, var(--dsw-alias-label-tertiary) 28%, transparent) transparent;
   scrollbar-width: thin;
@@ -334,8 +335,18 @@
 
 .teamHead {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   gap: 10px;
+  width: 100%;
+  min-width: 0;
+}
+
+.teamSummary {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
   min-width: 0;
 }
 
@@ -438,6 +449,23 @@
   flex: none;
   margin-top: 1px;
 }
+
+.teamActionRow { width: 100%; min-width: 0; }
+.teamActions { display: flex; flex-wrap: wrap; gap: 6px; width: 100%; min-width: 0; }
+.actionButton, .dangerButton {
+  flex: 1 1 88px; min-width: 0; padding: 3px 7px; border: 1px solid var(--dsw-alias-line-normal);
+  border-radius: 5px; background: var(--dsw-alias-bg-layer-1); color: var(--dsw-alias-label-secondary);
+  font: inherit; font-size: 10px; line-height: 16px; cursor: pointer;
+}
+.dangerButton { color: var(--dsw-alias-state-danger); border-color: var(--dsw-alias-state-danger); }
+.historyGroup { border-bottom: 1px solid var(--dsw-alias-line-normal); }
+.historyToggle {
+  display: flex; align-items: center; gap: 6px; width: 100%; padding: 9px 14px;
+  border: 0; background: var(--dsw-alias-bg-layer-1); color: var(--dsw-alias-label-secondary);
+  font: inherit; font-size: 11px; font-weight: 600; cursor: pointer;
+}
+.hiddenRow { display: flex; align-items: center; justify-content: space-between; gap: 8px; padding: 7px 14px; color: var(--dsw-alias-label-secondary); font-size: 11px; }
+.actionError { display: block; padding: 7px 14px; color: var(--dsw-alias-state-danger); font-size: 10px; line-height: 15px; }
 
 .sectionHead {
   display: flex;

--- a/src/client/ActivityPanel.tsx
+++ b/src/client/ActivityPanel.tsx
@@ -48,6 +48,7 @@ import {
   ACTIVITY_HALT_URL,
   getActivityMonitorTargetsSnapshot,
   getActivitySnapshotsSnapshot,
+  removeActivityTeam,
   startActivityPolling,
   subscribeActivityMonitorTargets,
   subscribeActivitySnapshots,
@@ -471,7 +472,7 @@ function DependencyMap({ tasks, members, t, discarded = false }: {
   )
 }
 
-function TeamSection({ team, modelDirectory, onContinuePlanning, onDiscarded, onNavigate, t, historic = false }: {
+function TeamSection({ team, modelDirectory, onContinuePlanning, onDiscarded, onNavigate, t, historic = false, actions, compactHistory = false }: {
   readonly team: ActivityTeam
   readonly modelDirectory?: ModelDirectory
   readonly onContinuePlanning?: () => void
@@ -480,6 +481,8 @@ function TeamSection({ team, modelDirectory, onContinuePlanning, onDiscarded, on
   readonly onNavigate: (parentId: SessionId, childId: SessionId) => void
   readonly t: AgentTeamsTranslate
   readonly historic?: boolean
+  readonly actions?: React.ReactNode
+  readonly compactHistory?: boolean
 }) {
   const [membersOpen, setMembersOpen] = useState(true)
   const [stopOpen, setStopOpen] = useState(false)
@@ -531,28 +534,32 @@ function TeamSection({ team, modelDirectory, onContinuePlanning, onDiscarded, on
   return (
     <>
       <section className={css.team} data-team-id={team.teamId}>
-        <header className={css.teamHead}>
-          <span className={css.teamName} title={team.name}>{team.name}</span>
-          {historic && <span className={css.historicPill}>{t(discarded ? 'team.discarded' : 'team.ended')}</span>}
-          {stopped && <span className={css.historicPill}>{t('team.stopped')}</span>}
-          <span className={css.teamStats}>
-            <span data-stat="members">{t('team.stats.members', { count: team.members.length })}</span>
-            <span data-stat="tasks">{t('team.stats.completed', { completed: completedCount, total: team.tasks.length })}</span>
-            <span data-stat="messages">{t('team.stats.messages', { count: team.messageCount })}</span>
+        <header className={css.teamHead} data-historic={historic || undefined}>
+          <span className={css.teamSummary}>
+            <span className={css.teamName} title={team.name}>{team.name}</span>
+            {historic && <span className={css.historicPill}>{t(discarded ? 'team.discarded' : 'team.ended')}</span>}
+            {stopped && <span className={css.historicPill}>{t('team.stopped')}</span>}
+            <span className={css.teamStats}>
+              <span data-stat="members">{t('team.stats.members', { count: team.members.length })}</span>
+              <span data-stat="tasks">{t('team.stats.completed', { completed: completedCount, total: team.tasks.length })}</span>
+              <span data-stat="messages">{t('team.stats.messages', { count: team.messageCount })}</span>
+            </span>
+            {canStop && (
+              <button
+                type="button"
+                className={css.teamStopButton}
+                aria-label={t('team.stop')}
+                title={t('team.stop')}
+                onClick={() => { setStopError(''); setStopOpen(true) }}
+              >
+                <IconStopFill16 />
+              </button>
+            )}
           </span>
-          {canStop && (
-            <button
-              type="button"
-              className={css.teamStopButton}
-              aria-label={t('team.stop')}
-              title={t('team.stop')}
-              onClick={() => { setStopError(''); setStopOpen(true) }}
-            >
-              <IconStopFill16 />
-            </button>
-          )}
+          {actions !== undefined && <span className={css.teamActionRow}>{actions}</span>}
         </header>
 
+        {compactHistory ? null : <>
         {team.phase === 'staged' && !historic && modelDirectory !== undefined && onContinuePlanning !== undefined && onDiscarded !== undefined && (
           <StagingPlanEditor
             team={team}
@@ -562,7 +569,6 @@ function TeamSection({ team, modelDirectory, onContinuePlanning, onDiscarded, on
             t={t}
           />
         )}
-
       <section className={css.delegationSection} aria-label={t('delegation.aria')} data-delegation-map>
         <div className={css.captainNode}>
           <span className={css.captainAvatar}>
@@ -704,8 +710,8 @@ function TeamSection({ team, modelDirectory, onContinuePlanning, onDiscarded, on
           })}
         </div>}
       </section>
-
       <DependencyMap tasks={team.tasks} members={team.members} t={t} discarded={discarded} />
+      </>}
       </section>
       <Modal
         open={stopOpen}
@@ -735,6 +741,7 @@ function historicCardTeam(data: AgentTeamsCardData, owner: string): ActivityTeam
   return {
     workspace: '',
     teamId: data.teamId,
+    generationId: data.generationId,
     name: data.teamName,
     captainSessionId: data.captainSessionId || owner,
     phase: 'running',
@@ -777,6 +784,13 @@ export function ActivityPanel({ sessionsList, modelDirectories, openMember, t }:
   const [autoOpened, setAutoOpened] = useState(false)
   const [wasActive, setWasActive] = useState(false)
   const [historic, setHistoric] = useState<ReadonlyMap<string, { data: AgentTeamsCardData; owner: string }>>(new Map())
+  const [historyOpen, setHistoryOpen] = useState(false)
+  const [hiddenOpen, setHiddenOpen] = useState(false)
+  const [expandedHistoric, setExpandedHistoric] = useState<ReadonlySet<string>>(new Set())
+  const [hiddenHistoric, setHiddenHistoric] = useState<ReadonlySet<string>>(() => {
+    try { return new Set(JSON.parse(window.localStorage.getItem('dsh-agent-teams:hidden-archives:v1') ?? '[]') as string[]) } catch { return new Set() }
+  })
+  const [actionError, setActionError] = useState('')
   const [layout, setLayout] = useState<PanelLayout>(initialPanelLayout)
   const [bounds, setBounds] = useState<PanelBounds>(initialPanelBounds)
   const [interaction, setInteraction] = useState<'dragging' | 'resizing' | null>(null)
@@ -805,7 +819,7 @@ export function ActivityPanel({ sessionsList, modelDirectories, openMember, t }:
       document.querySelector<HTMLTextAreaElement>('[data-composer-card] textarea')?.focus()
     })
   }
-  const { teams, archivedTeams } = useSyncExternalStore(
+  const { teams, archivedTeams, purgedTeams, actionToken } = useSyncExternalStore(
     subscribeActivitySnapshots,
     getActivitySnapshotsSnapshot,
   )
@@ -966,28 +980,53 @@ export function ActivityPanel({ sessionsList, modelDirectories, openMember, t }:
   )
   const visibleHistoric = useMemo(
     () => (current === undefined ? [] : [...historic.values()].filter(({ data, owner }) =>
-      owner === current && !teams.some((live) =>
+      !purgedTeams.some((purged) => purged.captainSessionId === owner && purged.teamId === data.teamId
+        && (purged.generationId === undefined || data.generationId === undefined || purged.generationId === data.generationId))
+      && owner === current && !teams.some((live) =>
         live.captainSessionId === current && live.teamId === data.teamId,
       ) && !archivedTeams.some((archived) =>
         archived.captainSessionId === current && archived.teamId === data.teamId,
       ),
     )),
-    [historic, current, teams, archivedTeams],
+    [historic, current, teams, archivedTeams, purgedTeams],
   )
   const visibleArchived = useMemo(
     () => (current === undefined ? [] : archivedTeams.filter((team) =>
-      team.captainSessionId === current && !teams.some((live) =>
+      !purgedTeams.some((purged) => purged.captainSessionId === current && purged.teamId === team.teamId
+        && (purged.generationId === undefined || purged.generationId === team.generationId))
+      && team.captainSessionId === current && !teams.some((live) =>
         live.captainSessionId === current && live.teamId === team.teamId,
       ),
     )),
-    [archivedTeams, current, teams],
+    [archivedTeams, current, teams, purgedTeams],
   )
-  const visibleCount = visibleTeams.length + visibleArchived.length + visibleHistoric.length
+  const historicTeams = useMemo(() => [
+    ...visibleArchived,
+    ...visibleHistoric.map(({ data, owner }) => historicCardTeam(data, owner)),
+  ], [visibleArchived, visibleHistoric])
+  const shownHistoric = historicTeams.filter((team) => !hiddenHistoric.has(`${team.captainSessionId}:${team.teamId}:${team.generationId}`))
+  const hiddenTeams = historicTeams.filter((team) => hiddenHistoric.has(`${team.captainSessionId}:${team.teamId}:${team.generationId}`))
+  const visibleCount = visibleTeams.length + shownHistoric.length + hiddenTeams.length
   const visibleLiveTeamIds = useMemo(
     () => visibleTeams.map((team) => team.teamId).sort(),
     [visibleTeams],
   )
   const visibleLiveTeamKey = visibleLiveTeamIds.join('\u0000')
+
+  useEffect(() => {
+    window.localStorage.setItem('dsh-agent-teams:hidden-archives:v1', JSON.stringify([...hiddenHistoric]))
+  }, [hiddenHistoric])
+
+  const runTeamAction = async (team: ActivityTeam, action: 'archive' | 'purge'): Promise<void> => {
+    setActionError('')
+    const response = await fetch('/plugins/dsh-agent-teams/team-action', {
+      method: 'POST', headers: { 'content-type': 'application/json', 'x-agent-teams-action-token': actionToken },
+      body: JSON.stringify({ action, workspace: team.workspace, captainSessionId: team.captainSessionId, teamId: team.teamId, generationId: team.generationId }),
+    })
+    const result = await response.json() as { ok?: boolean; error?: string }
+    if (!response.ok || result.ok !== true) throw new Error(result.error ?? `HTTP ${response.status}`)
+    removeActivityTeam(team.captainSessionId, team.teamId, team.generationId, action === 'purge')
+  }
 
   useEffect(() => {
     const tracker = autoOpenTrackerRef.current
@@ -1242,20 +1281,49 @@ export function ActivityPanel({ sessionsList, modelDirectories, openMember, t }:
                       onDiscarded={returnToComposer}
                       onNavigate={navigateToSession}
                       t={t}
+                      actions={
+                        <button className={css.actionButton} type="button" onClick={() => {
+                          if (!window.confirm(t('team.archiveConfirm', { name: team.name }))) return
+                          void runTeamAction(team, 'archive').catch((error: unknown) => { setActionError(t('action.failed', { message: String(error) })) })
+                        }}>{t('team.archive')}</button>
+                      }
                     />
                   ))}
-                  {visibleArchived.map((team) => (
-                    <div key={`${team.captainSessionId}:${team.teamId}`} data-team-id={team.teamId} data-historic className={css.archivedWrap}>
-                      <span className={css.archiveLabel}>{t(team.phase === 'staged' ? 'archive.discardedLabel' : 'archive.label')}</span>
-                      <TeamSection team={team} onNavigate={navigateToSession} t={t} historic />
-                    </div>
-                  ))}
-                  {visibleHistoric.map(({ data: team, owner }) => {
-                    const teamKey = `${owner}:${team.teamId}`
-                    return (
-                      <TeamSection key={teamKey} team={historicCardTeam(team, owner)} onNavigate={navigateToSession} t={t} historic />
-                    )
-                  })}
+                  {shownHistoric.length > 0 && <section className={css.historyGroup}>
+                    <button className={css.historyToggle} type="button" onClick={() => { setHistoryOpen((value) => !value) }}>
+                      <Chevron open={historyOpen} />{t('archive.group', { count: shownHistoric.length })}
+                    </button>
+                    {historyOpen && shownHistoric.map((team) => {
+                      const key = `${team.captainSessionId}:${team.teamId}:${team.generationId}`
+                      const expanded = expandedHistoric.has(key)
+                      return <div key={key} className={css.archivedWrap}>
+                        <span className={css.archiveLabel}>{t(team.phase === 'staged' ? 'archive.discardedLabel' : 'archive.label')}</span>
+                        <TeamSection
+                          team={team}
+                          onNavigate={navigateToSession}
+                          t={t}
+                          historic
+                          compactHistory={!expanded}
+                          actions={<span className={css.teamActions}>
+                            <button className={css.actionButton} type="button" onClick={() => { setExpandedHistoric((previous) => { const next = new Set(previous); expanded ? next.delete(key) : next.add(key); return next }) }}>{t(expanded ? 'archive.collapse' : 'archive.expand')}</button>
+                            <button className={css.actionButton} type="button" onClick={() => { setHiddenHistoric((previous) => new Set(previous).add(key)) }}>{t('archive.hide')}</button>
+                            <button className={css.dangerButton} type="button" onClick={() => {
+                              if (!window.confirm(t('archive.purgeConfirm', { name: team.name }))) return
+                              void runTeamAction(team, 'purge').catch((error: unknown) => { setActionError(t('action.failed', { message: String(error) })) })
+                            }}>{t('archive.purge')}</button>
+                          </span>}
+                        />
+                      </div>
+                    })}
+                  </section>}
+                  {hiddenTeams.length > 0 && <section className={css.historyGroup}>
+                    <button className={css.historyToggle} type="button" onClick={() => { setHiddenOpen((value) => !value) }}><Chevron open={hiddenOpen} />{t('archive.hiddenGroup', { count: hiddenTeams.length })}</button>
+                    {hiddenOpen && hiddenTeams.map((team) => {
+                      const key = `${team.captainSessionId}:${team.teamId}:${team.generationId}`
+                      return <div key={key} className={css.hiddenRow}><span>{team.name}</span><button className={css.actionButton} type="button" onClick={() => { setHiddenHistoric((previous) => { const next = new Set(previous); next.delete(key); return next }) }}>{t('archive.restore')}</button></div>
+                    })}
+                  </section>}
+                  {actionError !== '' && <span className={css.actionError}>{actionError}</span>}
                 </>
               )}
           </div>

--- a/src/client/AgentTeamsCard.tsx
+++ b/src/client/AgentTeamsCard.tsx
@@ -43,6 +43,7 @@ function openActivityPanel(data: AgentTeamsCardData): void {
   window.dispatchEvent(new CustomEvent(OPEN_PANEL_EVENT, {
     detail: {
       teamId: data.teamId,
+      generationId: data.generationId,
       captainSessionId: data.captainSessionId,
       teamName: data.teamName,
       members: data.members,
@@ -56,7 +57,7 @@ export function AgentTeamsCard({ node, openMember, sessionId, t }: AgentTeamsCar
   // `conversation.chat.node` is session-scoped, so its framework-owned id is
   // a stable owner even while another conversation becomes current.
   const owner = data.captainSessionId || sessionId
-  const { teams, archivedTeams } = useSyncExternalStore(
+  const { teams, archivedTeams, purgedTeams } = useSyncExternalStore(
     subscribeActivitySnapshots,
     getActivitySnapshotsSnapshot,
   )
@@ -71,6 +72,8 @@ export function AgentTeamsCard({ node, openMember, sessionId, t }: AgentTeamsCar
     teamName: snapshot?.name ?? data.teamName,
     members: snapshot?.members.map((member) => ({ id: member.id, name: member.name, role: member.role })) ?? data.members,
   }), [data, owner, snapshot])
+  if (purgedTeams.some((team) => team.captainSessionId === owner && team.teamId === data.teamId
+    && (data.generationId === '' || team.generationId === undefined || team.generationId === data.generationId))) return null
   return (
     <section className={css.root} data-agent-teams-card data-team-id={resolved.teamId}>
       <header className={css.head}>

--- a/src/client/activity-monitor.ts
+++ b/src/client/activity-monitor.ts
@@ -44,6 +44,7 @@ export interface ActivityMessage {
 export interface ActivityTeam {
   readonly workspace: string
   readonly teamId: string
+  readonly generationId: string
   readonly name: string
   readonly description?: string
   readonly captainSessionId: string
@@ -67,6 +68,14 @@ export interface ActivityMonitorTarget {
 export interface ActivitySnapshots {
   readonly teams: readonly ActivityTeam[]
   readonly archivedTeams: readonly ActivityTeam[]
+  readonly purgedTeams: readonly PurgedTeamIdentity[]
+  readonly actionToken: string
+}
+
+export interface PurgedTeamIdentity {
+  readonly captainSessionId: string
+  readonly teamId: string
+  readonly generationId?: string
 }
 
 interface RegisteredTarget extends ActivityMonitorTarget {
@@ -78,7 +87,7 @@ const targets = new Map<string, RegisteredTarget>()
 const targetListeners = new Set<() => void>()
 const snapshotListeners = new Set<() => void>()
 let targetSnapshot: readonly ActivityMonitorTarget[] = []
-let activitySnapshots: ActivitySnapshots = { teams: [], archivedTeams: [] }
+let activitySnapshots: ActivitySnapshots = { teams: [], archivedTeams: [], purgedTeams: [], actionToken: '' }
 
 function targetKey(sessionId: string, teamId: string): string {
   return `${sessionId}\u0000${teamId}`
@@ -166,10 +175,29 @@ export function updateActivitySnapshots(update: Partial<ActivitySnapshots>): voi
   const next = {
     teams: update.teams ?? activitySnapshots.teams,
     archivedTeams: update.archivedTeams ?? activitySnapshots.archivedTeams,
+    purgedTeams: update.purgedTeams ?? activitySnapshots.purgedTeams,
+    actionToken: update.actionToken ?? activitySnapshots.actionToken,
   }
-  if (next.teams === activitySnapshots.teams && next.archivedTeams === activitySnapshots.archivedTeams) return
+  if (next.teams === activitySnapshots.teams && next.archivedTeams === activitySnapshots.archivedTeams
+    && next.purgedTeams === activitySnapshots.purgedTeams && next.actionToken === activitySnapshots.actionToken) return
   activitySnapshots = next
   for (const listener of snapshotListeners) listener()
+}
+
+/** Apply a successful destructive panel action without waiting for polling. */
+export function removeActivityTeam(captainSessionId: string, teamId: string, generationId: string, purged: boolean): void {
+  const matches = (team: ActivityTeam): boolean => team.captainSessionId === captainSessionId
+    && team.teamId === teamId && team.generationId === generationId
+  const removedLive = activitySnapshots.teams.find(matches)
+  updateActivitySnapshots({
+    teams: activitySnapshots.teams.filter((team) => !matches(team)),
+    archivedTeams: purged
+      ? activitySnapshots.archivedTeams.filter((team) => !matches(team))
+      : removedLive === undefined ? activitySnapshots.archivedTeams : [...activitySnapshots.archivedTeams, removedLive],
+    purgedTeams: purged
+      ? [...activitySnapshots.purgedTeams, { captainSessionId, teamId, generationId }]
+      : activitySnapshots.purgedTeams,
+  })
 }
 
 /** Poll cadence for the live host snapshot route. */
@@ -269,10 +297,10 @@ export function startActivityPolling(
         signal: controller.signal,
       })
       if (!liveResponse.ok) return
-      const body = (await liveResponse.json()) as { teams?: unknown }
+      const body = (await liveResponse.json()) as { teams?: unknown; purgedTeams?: unknown; actionToken?: unknown }
       if (cancelled || !Array.isArray(body.teams)) return
       const liveTeams = body.teams as readonly ActivityTeam[]
-      publishSnapshots({ teams: liveTeams })
+      publishSnapshots({ teams: liveTeams, purgedTeams: Array.isArray(body.purgedTeams) ? body.purgedTeams as readonly PurgedTeamIdentity[] : [], actionToken: typeof body.actionToken === 'string' ? body.actionToken : '' })
       const previousDiscoveredKeys = discoveredLiveKeys
       discoveredLiveKeys = new Set(discoverySessionId === undefined || discoverySessionId === ''
         ? []
@@ -305,9 +333,13 @@ export function startActivityPolling(
         signal: controller.signal,
       })
       if (!archivedResponse.ok) return
-      const archivedBody = (await archivedResponse.json()) as { teams?: unknown }
+      const archivedBody = (await archivedResponse.json()) as { teams?: unknown; purgedTeams?: unknown; actionToken?: unknown }
       if (cancelled || !Array.isArray(archivedBody.teams)) return
-      publishSnapshots({ archivedTeams: archivedBody.teams as readonly ActivityTeam[] })
+      publishSnapshots({
+        archivedTeams: archivedBody.teams as readonly ActivityTeam[],
+        purgedTeams: Array.isArray(archivedBody.purgedTeams) ? archivedBody.purgedTeams as readonly PurgedTeamIdentity[] : [],
+        actionToken: typeof archivedBody.actionToken === 'string' ? archivedBody.actionToken : '',
+      })
       discoveryComplete = true
       settleTargets(new Set(missing.map((target) => target.key)))
     } catch (error: unknown) {

--- a/src/client/agent-teams-card-definition.ts
+++ b/src/client/agent-teams-card-definition.ts
@@ -25,6 +25,7 @@ import type {} from '@deepseek-ai/dsh-session/types'
 /** Final keyed Chat payload for the team summary card. */
 export interface AgentTeamsCardData {
   readonly teamId: string
+  readonly generationId: string
   /** The captain session that owns this team (panel follows it). */
   readonly captainSessionId: string
   readonly teamName: string
@@ -47,6 +48,7 @@ export interface AgentTeamsNodeState {
   readonly teamId: string
   readonly name: string
   readonly accepted: boolean
+  readonly generationId: string
 }
 
 /** Parse the only create-call fields the historic card owns. */
@@ -86,14 +88,20 @@ export const agentTeamsCardDefinition: ConversationNodeDefinition<AgentTeamsNode
     }
     const parsed = parseAgentTeamsCreateArgs(match.event.data.arguments)
     if (parsed === undefined) throw new Error('agent-teams card start requires valid create arguments')
-    return { ...parsed, accepted: false }
+    return { ...parsed, accepted: false, generationId: '' }
   },
   update: (context, match) => {
     if (match.event.type !== 'tool/result') return context.state
     const failed = match.event.data.error !== undefined
       || match.event.data.message.content.some((block) => block.type === 'tool-result' && block.isError === true)
     if (failed) return context.state
-    return { ...context.state, accepted: true }
+    // Extract generation id materialized by agent_teams_create render text.
+    // Note: The format is coupled with render output in src/tools.ts (`generation ${value.generation_id}`).
+    const text = match.event.data.message.content
+      .flatMap((block) => block.type === 'tool-result' ? block.content : [])
+      .find((block) => block.type === 'text')?.text ?? ''
+    const generationId = text.match(/\bgeneration ([^)\s]+)/u)?.[1] ?? ''
+    return { ...context.state, accepted: true, generationId }
   },
   buildViewNode: (context): ChatConversationViewNode | null => {
     if (context.start === undefined) return null
@@ -109,6 +117,7 @@ export const agentTeamsCardDefinition: ConversationNodeDefinition<AgentTeamsNode
       visibility: 'visible',
       data: {
         teamId: state.teamId,
+        generationId: state.generationId,
         captainSessionId: '',
         teamName: state.name,
         members: [],

--- a/src/client/locales.ts
+++ b/src/client/locales.ts
@@ -193,6 +193,17 @@ export const zh = {
   'assignment.empty': '暂无任务',
   'archive.label': '已结束 · 历史归档',
   'archive.discardedLabel': '计划已放弃 · 历史归档',
+  'archive.group': '历史团队（{count}）',
+  'archive.hiddenGroup': '已隐藏团队（{count}）',
+  'archive.expand': '展开历史',
+  'archive.collapse': '收起历史',
+  'archive.hide': '从面板隐藏',
+  'archive.restore': '重新显示',
+  'archive.purge': '永久删除',
+  'archive.purgeConfirm': '永久删除归档团队“{name}”？任务、成员和消息归档将被删除，此操作无法撤销。',
+  'team.archive': '结束并归档',
+  'team.archiveConfirm': '结束并归档团队“{name}”？系统将请求成员停止，历史记录会保留。',
+  'action.failed': '操作失败：{message}',
 } satisfies Record<string, string>
 
 /** AgentTeams namespace key union. */
@@ -388,6 +399,17 @@ export const en = {
   'assignment.empty': 'No tasks',
   'archive.label': 'Ended · Archived history',
   'archive.discardedLabel': 'Plan discarded · Archived history',
+  'archive.group': 'Historic teams ({count})',
+  'archive.hiddenGroup': 'Hidden teams ({count})',
+  'archive.expand': 'Expand history',
+  'archive.collapse': 'Collapse history',
+  'archive.hide': 'Hide from panel',
+  'archive.restore': 'Show again',
+  'archive.purge': 'Permanently delete',
+  'archive.purgeConfirm': 'Permanently delete archived team “{name}”? Its tasks, members, and messages will be removed. This cannot be undone.',
+  'team.archive': 'End and archive',
+  'team.archiveConfirm': 'End and archive team “{name}”? Members will be asked to stop and history will be retained.',
+  'action.failed': 'Action failed: {message}',
 } satisfies Record<AgentTeamsLocaleKey, string>
 
 /** Translation function consumed by pure view helpers. */

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,11 +22,13 @@ import z from '@deepseek-ai/schemastery'
 // Declaration merge only: makes ctx.llm, ctx.subagents and ctx.systemPrompt visible.
 import type {} from '@deepseek-ai/dsh-llm'
 import type {} from '@deepseek-ai/dsh-subagent'
+import type { IncomingMessage } from 'node:http'
 import type {} from '@deepseek-ai/dsh-system-prompt'
 import type { WorkspaceRegistry } from '@deepseek-ai/dsh-workspace'
 import {
   haltTeamWork,
   registerAgentTeamsTools,
+  waitForMemberIdle,
   type StagedPlanMutation,
   type ToolsConfig,
 } from './tools.ts'
@@ -34,12 +36,44 @@ import { installAgentTeamsGestureBoundary, registerAgentTeamsCommand } from './c
 import { readFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { collectArchivedTeamsActivity, collectTeamsActivity } from './snapshot.ts'
-import { findTeamByCaptain } from './state.ts'
+import { randomBytes, timingSafeEqual } from 'node:crypto'
+import { collectArchivedTeamsActivity, collectPurgedTeams, collectTeamsActivity } from './snapshot.ts'
+import {
+  archiveTeamDir, clearPurgedTeam, findTeamByCaptain, invalidateTaskAttempt, listArchivedTeamIds, readArchivedTeam, readTeam, recordPurgedTeam,
+  readRetiredMemberIds, recordRetiredMemberIds, removeTeamDir, unrecordRetiredMemberIds, withTeamLock, writeTeam,
+} from './state.ts'
 import { formatProfilesForPrompt, type TeamProfileConfig } from './profiles.ts'
 import { qualityPlanningPrompt } from './quality-gates.ts'
+import { interruptMember } from './members.ts'
 
 import { authenticatedWebRoutes, readJsonRequest, RequestBodyError, type BrowserRequestGate, type WebRouteHost } from './web-routes.ts'
+
+function teamLockKey(stateRoot: string, teamId: string): string {
+  return `team:${stateRoot}:${teamId}`
+}
+
+async function readJsonBody(req: IncomingMessage): Promise<Record<string, unknown>> {
+  const chunks: Buffer[] = []
+  let size = 0
+  for await (const chunk of req) {
+    const data = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)
+    size += data.length
+    if (size > 16_384) throw new Error('request body is too large')
+    chunks.push(data)
+  }
+  const parsed: unknown = JSON.parse(Buffer.concat(chunks).toString('utf8') || '{}')
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) throw new Error('invalid JSON body')
+  return parsed as Record<string, unknown>
+}
+
+function safeTokenEqual(actual: string, expected: string): boolean {
+  const left = Buffer.from(actual); const right = Buffer.from(expected)
+  return left.length === right.length && timingSafeEqual(left, right)
+}
+
+function isLoopback(address: string | undefined): boolean {
+  return address === '127.0.0.1' || address === '::1' || address === '::ffff:127.0.0.1'
+}
 
 /** Web-server service key candidates, newest first. */
 const WEB_SERVER_KEYS = ['webServer', 'httpServer'] as const
@@ -220,6 +254,7 @@ export function apply(ctx: Context, config: Config): void {
     if (rawWebServer === undefined || workspaceRegistry === undefined) return
     const webServer = authenticatedWebRoutes(rawWebServer, () => ctx.get('connection') as BrowserRequestGate | undefined)
     webRegistered = true
+    const actionToken = randomBytes(32).toString('base64url')
 
     // Activity panel data route: the browser floater polls this for team
     // snapshots (disk truth + live subagent activity). Mirrors the Claude
@@ -237,7 +272,7 @@ export function apply(ctx: Context, config: Config): void {
       const snapshots = url.searchParams.get('archived') === '1'
         ? await collectArchivedTeamsActivity(ctx, roots)
         : await collectTeamsActivity(ctx, roots)
-      const body = JSON.stringify({ teams: snapshots })
+      const body = JSON.stringify({ teams: snapshots, purgedTeams: await collectPurgedTeams(roots), actionToken })
       res.writeHead(200, {
         'content-type': 'application/json; charset=utf-8',
         'cache-control': 'no-store',
@@ -424,6 +459,82 @@ export function apply(ctx: Context, config: Config): void {
         }
       },
     }), 'agent-teams: plan route')
+
+    ctx.effect(() => webServer.register({
+      kind: 'exact',
+      path: '/plugins/dsh-agent-teams/team-action',
+      handler: async (req, res) => {
+        try {
+          if (req.method !== 'POST') { res.writeHead(405, { allow: 'POST' }); res.end(); return }
+          if (!isLoopback(req.socket.remoteAddress)) throw new Error('team actions are restricted to loopback clients')
+          const origin = req.headers.origin
+          const host = req.headers.host
+          if (typeof origin !== 'string' || typeof host !== 'string' || new URL(origin).host !== host) throw new Error('same-origin request required')
+          if (!(req.headers['content-type'] ?? '').toLowerCase().startsWith('application/json')) throw new Error('application/json is required')
+          const suppliedToken = req.headers['x-agent-teams-action-token']
+          if (typeof suppliedToken !== 'string' || !safeTokenEqual(suppliedToken, actionToken)) throw new Error('invalid action capability')
+          const body = await readJsonBody(req)
+          const { action, teamId, generationId, captainSessionId, workspace: workspacePath } = body
+          if (typeof action !== 'string' || typeof teamId !== 'string' || typeof generationId !== 'string'
+            || typeof captainSessionId !== 'string' || typeof workspacePath !== 'string') {
+            throw new Error('action, workspace, captainSessionId, teamId and generationId are required')
+          }
+          const candidates = workspaceRegistry.list().filter((entry) => entry.title === workspacePath)
+          if (candidates.length !== 1) throw new Error('workspace is not uniquely registered')
+          const workspace = candidates[0]!
+          const stateRoot = join(workspace.path, resolved.stateDir)
+          await withTeamLock(teamLockKey(stateRoot, teamId), async () => {
+            if (action === 'archive') {
+              const team = await readTeam(stateRoot, teamId)
+              if (team === undefined) throw new Error('active team was not found')
+              if (team.captainSessionId !== captainSessionId || String(team.createdAt) !== generationId) throw new Error('team ownership or generation mismatch')
+              const captain = ctx.agents.get(captainSessionId as import('@deepseek-ai/dsh-session').SessionId)
+              if (captain === undefined) throw new Error('captain session is not currently active')
+              const memberIds = team.members.map((member) => member.id).filter(Boolean)
+              const alreadyRetired = await readRetiredMemberIds(stateRoot)
+              const newlyRetired = memberIds.filter((id) => !alreadyRetired.has(id))
+              const original = structuredClone(team)
+              for (const member of team.members) {
+                member.status = 'removed'
+                for (const task of team.tasks) {
+                  if (task.assignee === member.name && task.status !== 'completed') invalidateTaskAttempt(task)
+                }
+              }
+              await writeTeam(stateRoot, team)
+              try { await recordRetiredMemberIds(stateRoot, newlyRetired) } catch (error) {
+                await writeTeam(stateRoot, original)
+                throw error
+              }
+              try { await archiveTeamDir(stateRoot, teamId) } catch (error) {
+                await unrecordRetiredMemberIds(stateRoot, newlyRetired)
+                await writeTeam(stateRoot, original)
+                throw error
+              }
+              for (const id of memberIds) interruptMember(ctx, captain, id)
+              await Promise.allSettled(team.members.map((member) => waitForMemberIdle(ctx, member, AbortSignal.timeout(15_000))))
+            } else if (action === 'purge') {
+              if (await readTeam(stateRoot, teamId) !== undefined) throw new Error('active teams cannot be purged')
+              const archivedIds = await listArchivedTeamIds(stateRoot)
+              if (!archivedIds.includes(teamId)) throw new Error('archived team was not found in directory listing')
+              const team = await readArchivedTeam(stateRoot, teamId)
+              if (team === undefined) throw new Error('archived team was not found')
+              if (team.captainSessionId !== captainSessionId || String(team.createdAt) !== generationId) throw new Error('team ownership or generation mismatch')
+              const identity = { captainSessionId, teamId, generationId }
+              await recordPurgedTeam(stateRoot, identity)
+              try { await removeTeamDir(join(stateRoot, 'archive'), teamId) } catch (error) {
+                await clearPurgedTeam(stateRoot, identity)
+                throw error
+              }
+            } else throw new Error('unsupported team action')
+          })
+          res.writeHead(200, { 'content-type': 'application/json; charset=utf-8', 'cache-control': 'no-store' })
+          res.end(JSON.stringify({ ok: true }))
+        } catch (error: unknown) {
+          res.writeHead(400, { 'content-type': 'application/json; charset=utf-8', 'cache-control': 'no-store' })
+          res.end(JSON.stringify({ ok: false, error: error instanceof Error ? error.message : String(error) }))
+        }
+      },
+    }), 'agent-teams: team action route')
 
   // Whale mascot artwork: serve the packaged V2 role/action images to the
   // activity panel. An explicit allowlist guards the route (no path

--- a/src/snapshot.ts
+++ b/src/snapshot.ts
@@ -13,9 +13,10 @@ import { readdir } from 'node:fs/promises'
 import { join } from 'node:path'
 import { memberActivity } from './members.ts'
 import {
-  CAPTAIN_KEY, listArchivedTeamIds, readArchivedTeam, readUnreadMailbox, readTeam,
+  CAPTAIN_KEY, listArchivedTeamIds, readArchivedTeam, readPurgedTeams, readUnreadMailbox, readTeam,
   taskDepthsById, taskVisualState,
 } from './state.ts'
+import type { PurgedTeamIdentity } from './state.ts'
 import type { MemberStatus, TeamState, TeamTask } from './types.ts'
 
 /** Visual task state for the activity panel. */
@@ -65,6 +66,7 @@ export interface TeamActivityMessage {
 export interface TeamActivitySnapshot {
   readonly workspace: string
   readonly teamId: string
+  readonly generationId: string
   readonly name: string
   readonly description?: string
   readonly captainSessionId: string
@@ -166,6 +168,7 @@ export async function assembleTeamSnapshot(
   return {
     workspace,
     teamId: state.id,
+    generationId: String(state.createdAt),
     name: state.name,
     ...state.description !== undefined ? { description: state.description } : {},
     captainSessionId: state.captainSessionId,
@@ -264,4 +267,12 @@ export async function collectArchivedTeamsActivity(
     }
   }
   return snapshots
+}
+
+export async function collectPurgedTeams(
+  roots: readonly { workspace: string; stateRoot: string }[],
+): Promise<PurgedTeamIdentity[]> {
+  const result: PurgedTeamIdentity[] = []
+  for (const root of roots) result.push(...await readPurgedTeams(root.stateRoot))
+  return result
 }

--- a/src/state.ts
+++ b/src/state.ts
@@ -47,6 +47,13 @@ export const CAPTAIN_KEY = 'captain'
 const MAILBOX_DELIVERY_LEASE_MS = 60_000
 /** Durable deny-list for AgentTeams members that must never be resumed. */
 const RETIRED_MEMBERS_FILE = 'retired-members.json'
+const PURGED_TEAMS_FILE = 'purged-teams.json'
+
+export interface PurgedTeamIdentity {
+  readonly captainSessionId: string
+  readonly teamId: string
+  readonly generationId?: string
+}
 
 /** In-process per-team mutation queues (promise chains). */
 const locks = new Map<string, Promise<unknown>>()
@@ -844,6 +851,53 @@ function isTeamMessage(value: unknown): value is TeamMessage {
  */
 export async function removeTeamDir(stateRoot: string, teamId: string): Promise<void> {
   await rm(join(stateRoot, teamId), { recursive: true, force: true })
+}
+
+/** Atomically undo retirement for exactly the supplied ids after a failed archive. */
+export async function unrecordRetiredMemberIds(stateRoot: string, memberIds: readonly string[]): Promise<void> {
+  const removals = new Set(memberIds.filter(id => id !== ''))
+  if (removals.size === 0) return
+  await withTeamLock(`retired-members:${stateRoot}`, async () => {
+    const retired = await readRetiredMemberIds(stateRoot)
+    for (const id of removals) retired.delete(id)
+    await mkdir(stateRoot, { recursive: true })
+    await atomicWriteText(join(stateRoot, RETIRED_MEMBERS_FILE), `${JSON.stringify([...retired].sort(), null, 2)}\n`)
+  })
+}
+
+export async function readPurgedTeams(stateRoot: string): Promise<PurgedTeamIdentity[]> {
+  try {
+    const value: unknown = JSON.parse(stripLeadingBom(await readFile(join(stateRoot, PURGED_TEAMS_FILE), 'utf8')))
+    if (!Array.isArray(value)) throw new Error('invalid AgentTeams purged-team registry')
+    return value.filter((entry): entry is PurgedTeamIdentity => isRecord(entry)
+      && typeof entry.captainSessionId === 'string' && entry.captainSessionId !== ''
+      && typeof entry.teamId === 'string' && entry.teamId !== ''
+      && (entry.generationId === undefined || typeof entry.generationId === 'string'))
+  } catch (error: unknown) {
+    if (error instanceof Error && 'code' in error && (error as NodeJS.ErrnoException).code === 'ENOENT') return []
+    throw error
+  }
+}
+
+export async function recordPurgedTeam(stateRoot: string, identity: PurgedTeamIdentity): Promise<void> {
+  await withTeamLock(`purged-teams:${stateRoot}`, async () => {
+    await mkdir(stateRoot, { recursive: true })
+    const current = await readPurgedTeams(stateRoot)
+    if (current.some((entry) => entry.captainSessionId === identity.captainSessionId
+      && entry.teamId === identity.teamId && entry.generationId === identity.generationId)) return
+    await atomicWriteText(join(stateRoot, PURGED_TEAMS_FILE), JSON.stringify([...current, identity], null, 2))
+  })
+}
+
+export async function clearPurgedTeam(stateRoot: string, identity: PurgedTeamIdentity): Promise<void> {
+  await withTeamLock(`purged-teams:${stateRoot}`, async () => {
+    const current = await readPurgedTeams(stateRoot)
+    const next = current.filter((entry) => !(entry.captainSessionId === identity.captainSessionId
+      && entry.teamId === identity.teamId && entry.generationId === identity.generationId))
+    if (next.length === current.length) return
+    if (next.length === 0) { await rm(join(stateRoot, PURGED_TEAMS_FILE), { force: true }); return }
+    await atomicWriteText(join(stateRoot, PURGED_TEAMS_FILE), JSON.stringify(next, null, 2))
+  })
 }
 
 /**

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -292,7 +292,7 @@ function captainOpenTask(team: TeamState, exceptTaskId?: string): TeamTask | und
     && !TERMINAL_TASK_STATUSES.includes(task.status))
 }
 
-async function waitForMemberIdle(ctx: Context, member: TeamMember, signal: AbortSignal): Promise<void> {
+export async function waitForMemberIdle(ctx: Context, member: TeamMember, signal: AbortSignal): Promise<void> {
   if (member.id === '') return
   const live = ctx.agents.get(member.id as SessionId)
   if (live === undefined) return
@@ -693,6 +693,7 @@ export function registerAgentTeamsTools(ctx: Context, config: ToolsConfig): Agen
         properties: {
           team_id: { type: 'string', required: true },
           team_name: { type: 'string', required: true },
+          generation_id: { type: 'string', required: true },
           state_dir: { type: 'string', required: true },
           phase: { type: 'string', required: true },
           profile: { type: 'string' },
@@ -704,8 +705,8 @@ export function registerAgentTeamsTools(ctx: Context, config: ToolsConfig): Agen
       render: (args, value) => [{
         type: 'text',
         text: value.phase === 'staged'
-          ? `Team "${value.team_name}" plan created under ${value.state_dir}. It is staged: finish the roster and DAG, then wait for the user to edit and approve it. Do not start or approve it yourself.`
-          : `Team "${value.team_name}" created (id ${value.team_id}) under ${value.state_dir}. You are the captain.`,
+          ? `Team "${value.team_name}" plan created (id ${value.team_id}, generation ${value.generation_id}) under ${value.state_dir}. It is staged: finish the roster and DAG, then wait for the user to edit and approve it. Do not start or approve it yourself.`
+          : `Team "${value.team_name}" created (id ${value.team_id}, generation ${value.generation_id}) under ${value.state_dir}. You are the captain.`,
       }],
     },
     async execute(args, exec) {
@@ -804,6 +805,7 @@ export function registerAgentTeamsTools(ctx: Context, config: ToolsConfig): Agen
         return {
           team_id: snapshot.id,
           team_name: snapshot.name,
+          generation_id: String(snapshot.createdAt),
           state_dir: join(stateRoot, snapshot.id),
           phase: snapshot.phase ?? 'running',
         }
@@ -811,6 +813,7 @@ export function registerAgentTeamsTools(ctx: Context, config: ToolsConfig): Agen
       return {
         team_id: snapshot.id,
         team_name: snapshot.name,
+        generation_id: String(snapshot.createdAt),
         state_dir: join(stateRoot, snapshot.id),
         phase: snapshot.phase ?? 'running',
         profile: snapshot.profile.name,


### PR DESCRIPTION
## Summary

- Group archived teams into a collapsed history section with compact summaries.
- Add reversible hide and restore controls backed by browser-local preferences.
- Add end-and-archive and permanent purge actions with confirmations.
- Track team generations so same-name teams remain isolated across history and purge.
- Keep action controls responsive in narrow panels without horizontal overflow.

## Host safety

- Restrict destructive actions to loopback, same-origin JSON requests.
- Require a per-process action capability and enforce a 16 KiB request limit.
- Revalidate workspace, captain session, team ID, generation, and lifecycle state on the host.
- Roll back team state and differential member retirement if archiving fails.
- Persist generation-specific purge tombstones so immutable conversation cards stay hidden without rewriting session logs.

## Verification

- pnpm typecheck
- pnpm build
- node scripts/lifecycle-verify.mjs
- node scripts/stress-verify.mjs
- Targeted offline checks for panel actions and responsive wrapping.

The offline verification passes all relevant checks. Its existing Windows transient-directory-lock timing check for archiveTeamDir remains flaky with EPERM; this change does not modify that retry implementation.