### PR TITLE
fix: preserve working state color fallback

### DIFF
--- a/scripts/verify.mjs
+++ b/scripts/verify.mjs
@@ -303,6 +303,13 @@ check(
   'missing token bridges make panel fills and DAG borders transparent',
 )
 check(
+  'working member and captain states use the fallback-bearing business color bridge',
+  activityPanelSource.includes('data-activity={member.activity}')
+    && activityPanelCss.includes(".memberState[data-activity='working']")
+    && /\.memberState\[data-activity='working'\][^{]*\{[^}]*color:\s*var\(--dsw-alias-bg-fill-business\)/su.test(activityPanelCss),
+  'an unguarded host business token makes the working label and glyph fall back to tertiary gray',
+)
+check(
   'activity panel uses the shell overlay instead of a page-breaking body portal',
   clientIndexSource.includes("ctx.slots.inject('shell.overlay'")
     && !clientIndexSource.includes('createRoot')

--- a/src/client/ActivityPanel.module.css
+++ b/src/client/ActivityPanel.module.css
@@ -476,7 +476,7 @@
 
 .captainState[data-busy='true'],
 .memberState[data-activity='working'] {
-  color: var(--dsw-alias-state-business-primary);
+  color: var(--dsw-alias-bg-fill-business);
 }
 
 .workGlyph rect {


### PR DESCRIPTION
## Summary

- use the panel fallback-bearing business color alias for working member and captain states
- add a verification assertion that pins the working-state selector to that compatibility bridge

## Root cause

The DOM and selector were correct, but the color used an unguarded host token. When that token is absent, the working label and currentColor glyph retain the tertiary gray base color.

## Verification

- pnpm typecheck
- pnpm build
- node scripts/verify.mjs (new assertion passes; existing Windows transient directory-lock EPERM remains environment-sensitive)