### PR TITLE
fix: recover parked tasks after member loss

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -86,7 +86,7 @@
 
 ## 使用协议
 
-插件提示段会指导模型按两阶段协议执行：创建 staged 团队 → 写入可编辑成员占位 → 拆任务并声明依赖 → 等待用户审查 → **Approve & Run** 后原子创建成员并启动调度 → 队长监控/引导 → 汇报后 `agent_teams_delete`。staged 阶段没有子会话、不会领取任务。只有用户明确要求跳过审查时才使用 `approval: automatic`。成员之间可以直接互发消息，无需队长中转。驻留成员在中断或正常结束一轮后若仍持有 `claimed/in_progress` 任务，该 attempt 会停驻；只有显式重试/转派/接管才会撤销它。若该停驻成员随后不再出现在 live Agent registry，下一次 Captain 状态检查或调度 kick 会创建新的 attempt 并重新唤醒原成员，避免任务永久显示进行中但没有 Agent 运行。
+插件提示段会指导模型按两阶段协议执行：创建 staged 团队 → 写入可编辑成员占位 → 拆任务并声明依赖 → 等待用户审查 → **Approve & Run** 后原子创建成员并启动调度 → 队长监控/引导 → 汇报后 `agent_teams_delete`。staged 阶段没有子会话、不会领取任务。只有用户明确要求跳过审查时才使用 `approval: automatic`。成员之间可以直接互发消息，无需队长中转。驻留成员在中断或正常结束一轮后若仍持有 `claimed/in_progress` 任务，该 attempt 会停驻；只有显式重试/转派/接管才会撤销它。本进程已经观察过的停驻 attempt 在 Harness 回收其 AgentHandle 后仍保持原 attempt，Captain 轮询 `agent_teams_status` 不会因此重铸。只有冷启动或从未被本进程观察过的开放任务，才会自动恢复一次；恢复投递失败会回到原来的 capability，而不会变成可无限重派的 `pending`。
 
 ## 命名多角色 profiles
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -86,7 +86,7 @@
 
 ## 使用协议
 
-插件提示段会指导模型按两阶段协议执行：创建 staged 团队 → 写入可编辑成员占位 → 拆任务并声明依赖 → 等待用户审查 → **Approve & Run** 后原子创建成员并启动调度 → 队长监控/引导 → 汇报后 `agent_teams_delete`。staged 阶段没有子会话、不会领取任务。只有用户明确要求跳过审查时才使用 `approval: automatic`。成员之间可以直接互发消息，无需队长中转。驻留成员在中断或正常结束一轮后若仍持有 `claimed/in_progress` 任务，该 attempt 会停驻；只有显式重试/转派/接管才会撤销它。
+插件提示段会指导模型按两阶段协议执行：创建 staged 团队 → 写入可编辑成员占位 → 拆任务并声明依赖 → 等待用户审查 → **Approve & Run** 后原子创建成员并启动调度 → 队长监控/引导 → 汇报后 `agent_teams_delete`。staged 阶段没有子会话、不会领取任务。只有用户明确要求跳过审查时才使用 `approval: automatic`。成员之间可以直接互发消息，无需队长中转。驻留成员在中断或正常结束一轮后若仍持有 `claimed/in_progress` 任务，该 attempt 会停驻；只有显式重试/转派/接管才会撤销它。若该停驻成员随后不再出现在 live Agent registry，下一次 Captain 状态检查或调度 kick 会创建新的 attempt 并重新唤醒原成员，避免任务永久显示进行中但没有 Agent 运行。
 
 ## 命名多角色 profiles
 

--- a/scripts/lifecycle-verify.mjs
+++ b/scripts/lifecycle-verify.mjs
@@ -752,10 +752,8 @@ try {
   // must be idempotent until the captain performs an explicit reassignment.
   publishStatus(alpha, 'idle')
   await new Promise(resolve => setTimeout(resolve, 20))
-  // Normal continuable settlement disposes its live AgentHandle between
-  // turns. The process-local idle observation must still distinguish this
-  // parked attempt from a cold process restart.
-  liveAgents.delete(alpha.id)
+  // The idle member remains resident, so repeated status kicks must keep
+  // its current attempt parked rather than spuriously waking it again.
   const deliveriesBeforeParkedKicks = deliveries.length
   await Promise.all([
     call('agent_teams_status', {}),
@@ -769,6 +767,22 @@ try {
       && parkedAlpha.attempt === alphaClaim.attempt
       && parkedAlpha.attemptId === alphaClaim.attempt_id
       && deliveries.length === deliveriesBeforeParkedKicks)
+  liveAgents.set(alpha.id, alpha)
+
+  // A later cold-loss differs from the intentionally parked resident case:
+  // the owner has no live AgentHandle, so a captain status kick must start a
+  // fresh attempt rather than leaving the task claimed forever.
+  liveAgents.delete(alpha.id)
+  const deliveriesBeforeColdRecovery = deliveries.length
+  await call('agent_teams_status', {})
+  await new Promise(resolve => setTimeout(resolve, 20))
+  const coldRecoveredAlpha = await task(t1.task_id)
+  check('missing parked owner is redispatched with a fresh attempt',
+    coldRecoveredAlpha?.status === 'claimed'
+      && coldRecoveredAlpha.assignee === 'alpha'
+      && coldRecoveredAlpha.attempt === alphaClaim.attempt + 1
+      && coldRecoveredAlpha.attemptId !== alphaClaim.attempt_id
+      && deliveries.length === deliveriesBeforeColdRecovery + 1)
   liveAgents.set(alpha.id, alpha)
 
   publishStatus(beta, 'idle')
@@ -798,10 +812,10 @@ try {
     task_id: t1.task_id, assignee: 'gamma', reason: 'alpha is stuck',
   })
   const reassigned = await task(t1.task_id)
-  check('reassignment quiesces old owner and creates a new attempt',
+  check('reassignment quiesces recovered owner and creates a new attempt',
     takeover.assignee === 'gamma' && reassigned?.status === 'claimed'
-      && reassigned.attemptId !== alphaClaim.attempt_id
-      && takeover.attempt === alphaClaim.attempt + 1)
+      && reassigned.attemptId !== coldRecoveredAlpha?.attemptId
+      && takeover.attempt === (coldRecoveredAlpha?.attempt ?? 0) + 1)
   let staleRejected = false
   try {
     await call('agent_teams_update_task', {

--- a/scripts/lifecycle-verify.mjs
+++ b/scripts/lifecycle-verify.mjs
@@ -769,21 +769,100 @@ try {
       && deliveries.length === deliveriesBeforeParkedKicks)
   liveAgents.set(alpha.id, alpha)
 
-  // A later cold-loss differs from the intentionally parked resident case:
-  // the owner has no live AgentHandle, so a captain status kick must start a
-  // fresh attempt rather than leaving the task claimed forever.
+  // Harness normally disposes a continuable AgentHandle after settlement. The
+  // in-process idle observation remains authoritative, so a non-resident
+  // parked owner must not be mistaken for a cold restart on every status poll.
   liveAgents.delete(alpha.id)
+  const deliveriesBeforeDisposedParkedKicks = deliveries.length
+  await Promise.all([
+    call('agent_teams_status', {}),
+    call('agent_teams_status', {}),
+    call('agent_teams_status', {}),
+  ])
+  await new Promise(resolve => setTimeout(resolve, 20))
+  const disposedParkedAlpha = await task(t1.task_id)
+  check('disposed settled owner keeps its parked attempt across repeated scheduler kicks',
+    disposedParkedAlpha?.status === 'in_progress'
+      && disposedParkedAlpha.attempt === alphaClaim.attempt
+      && disposedParkedAlpha.attemptId === alphaClaim.attempt_id
+      && deliveries.length === deliveriesBeforeDisposedParkedKicks)
+  liveAgents.set(alpha.id, alpha)
+
+  // Unobserved recovery whose followup fails must restore the original open
+  // capability and consume that generation's budget. Later status kicks must
+  // not recast it into pending or a new attempt.
+  const tRecoverFail = await call('agent_teams_create_task', {
+    subject: 'unobserved recovery delivery failure', assignee: 'gamma',
+  })
+  const recoverFailDispatch = await task(tRecoverFail.task_id)
+  check('idle assigned gamma is claimed for the recovery-failure fixture',
+    recoverFailDispatch?.status === 'claimed' && recoverFailDispatch.assignee === 'gamma')
+  const recoverFailClaim = await call('agent_teams_claim_task', { task_id: tRecoverFail.task_id }, gamma)
+  await call('agent_teams_update_task', {
+    task_id: tRecoverFail.task_id, status: 'in_progress', attempt_id: recoverFailClaim.attempt_id,
+  }, gamma)
+  liveAgents.delete(gamma.id)
+  failNextDelivery.add(gamma.id)
+  const deliveriesBeforeFailedRecovery = deliveries.length
+  await call('agent_teams_status', {})
+  await new Promise(resolve => setTimeout(resolve, 20))
+  const rolledBackRecovery = await task(tRecoverFail.task_id)
+  await Promise.all([
+    call('agent_teams_status', {}),
+    call('agent_teams_status', {}),
+    call('agent_teams_status', {}),
+  ])
+  await new Promise(resolve => setTimeout(resolve, 20))
+  const throttledFailedRecovery = await task(tRecoverFail.task_id)
+  check('failed unobserved recovery restores the original capability and later kicks do not recast it',
+    rolledBackRecovery?.status === 'in_progress'
+      && rolledBackRecovery.assignee === 'gamma'
+      && rolledBackRecovery.attempt === recoverFailClaim.attempt
+      && rolledBackRecovery.attemptId === recoverFailClaim.attempt_id
+      && deliveries.length === deliveriesBeforeFailedRecovery
+      && throttledFailedRecovery?.status === 'in_progress'
+      && throttledFailedRecovery.attempt === recoverFailClaim.attempt
+      && throttledFailedRecovery.attemptId === recoverFailClaim.attempt_id
+      && deliveries.length === deliveriesBeforeFailedRecovery)
+  liveAgents.set(gamma.id, gamma)
+  const recoverFailComplete = await call('agent_teams_claim_task', { task_id: tRecoverFail.task_id }, gamma)
+  await call('agent_teams_update_task', {
+    task_id: tRecoverFail.task_id,
+    status: 'completed',
+    output: 'closed failed-recovery fixture',
+    attempt_id: recoverFailComplete.attempt_id,
+  }, gamma)
+  check('restored capability remains usable after a failed recovery delivery',
+    recoverFailComplete.attempt_id === recoverFailClaim.attempt_id
+      && (await task(tRecoverFail.task_id))?.status === 'completed')
+  publishStatus(gamma, 'idle')
+
+  // A durable task with no process-local idle observation is a cold/unobserved
+  // owner. It gets exactly one fresh capability, then the recovery marker is
+  // sticky even if the new AgentHandle is still absent on later status kicks.
+  liveAgents.delete(beta.id)
   const deliveriesBeforeColdRecovery = deliveries.length
   await call('agent_teams_status', {})
   await new Promise(resolve => setTimeout(resolve, 20))
-  const coldRecoveredAlpha = await task(t1.task_id)
-  check('missing parked owner is redispatched with a fresh attempt',
-    coldRecoveredAlpha?.status === 'claimed'
-      && coldRecoveredAlpha.assignee === 'alpha'
-      && coldRecoveredAlpha.attempt === alphaClaim.attempt + 1
-      && coldRecoveredAlpha.attemptId !== alphaClaim.attempt_id
-      && deliveries.length === deliveriesBeforeColdRecovery + 1)
-  liveAgents.set(alpha.id, alpha)
+  const coldRecoveredBeta = await task(t2.task_id)
+  const deliveriesAfterColdRecovery = deliveries.length
+  await Promise.all([
+    call('agent_teams_status', {}),
+    call('agent_teams_status', {}),
+    call('agent_teams_status', {}),
+  ])
+  await new Promise(resolve => setTimeout(resolve, 20))
+  const throttledRecoveredBeta = await task(t2.task_id)
+  check('unobserved missing owner recovers once and repeated kicks do not rotate it again',
+    coldRecoveredBeta?.status === 'claimed'
+      && coldRecoveredBeta.assignee === 'beta'
+      && coldRecoveredBeta.attempt === betaClaim.attempt + 1
+      && coldRecoveredBeta.attemptId !== betaClaim.attempt_id
+      && deliveriesAfterColdRecovery === deliveriesBeforeColdRecovery + 1
+      && throttledRecoveredBeta?.attempt === coldRecoveredBeta.attempt
+      && throttledRecoveredBeta?.attemptId === coldRecoveredBeta.attemptId
+      && deliveries.length === deliveriesAfterColdRecovery)
+  liveAgents.set(beta.id, beta)
 
   publishStatus(beta, 'idle')
   await new Promise(resolve => setTimeout(resolve, 20))
@@ -795,8 +874,8 @@ try {
   check('captain message resumes a parked owner without rotating its attempt',
     resumedBeta.delivered === 'wake'
       && deliveries.length === deliveriesBeforeResume + 1
-      && resumedBetaTask?.attempt === betaClaim.attempt
-      && resumedBetaTask.attemptId === betaClaim.attempt_id)
+      && resumedBetaTask?.attempt === coldRecoveredBeta?.attempt
+      && resumedBetaTask.attemptId === coldRecoveredBeta?.attemptId)
 
   let unsafeCaptainTakeoverRejected = false
   try {
@@ -814,8 +893,8 @@ try {
   const reassigned = await task(t1.task_id)
   check('reassignment quiesces recovered owner and creates a new attempt',
     takeover.assignee === 'gamma' && reassigned?.status === 'claimed'
-      && reassigned.attemptId !== coldRecoveredAlpha?.attemptId
-      && takeover.attempt === (coldRecoveredAlpha?.attempt ?? 0) + 1)
+      && reassigned.attemptId !== disposedParkedAlpha?.attemptId
+      && takeover.attempt === (disposedParkedAlpha?.attempt ?? 0) + 1)
   let staleRejected = false
   try {
     await call('agent_teams_update_task', {
@@ -833,12 +912,16 @@ try {
   await call('agent_teams_update_task', {
     task_id: t1.task_id, status: 'completed', output: 'gamma result', attempt_id: gammaClaim.attempt_id,
   }, gamma)
+  const recoveredBetaClaim = await call('agent_teams_claim_task', { task_id: t2.task_id }, beta)
   await call('agent_teams_update_task', {
-    task_id: t2.task_id, status: 'completed', output: 'beta result', attempt_id: betaClaim.attempt_id,
+    task_id: t2.task_id, status: 'in_progress', attempt_id: recoveredBetaClaim.attempt_id,
   }, beta)
-  check('resumed member completes with the original parked capability',
+  await call('agent_teams_update_task', {
+    task_id: t2.task_id, status: 'completed', output: 'beta result', attempt_id: recoveredBetaClaim.attempt_id,
+  }, beta)
+  check('resumed recovered member completes with its throttled capability',
     (await task(t2.task_id))?.status === 'completed'
-      && (await task(t2.task_id))?.attemptId === betaClaim.attempt_id)
+      && (await task(t2.task_id))?.attemptId === recoveredBetaClaim.attempt_id)
   publishStatus(beta, 'idle')
   publishStatus(gamma, 'idle')
   await new Promise(resolve => setTimeout(resolve, 20))

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -8,7 +8,7 @@
  * the selected durable member. A resident member that becomes idle while it
  * still owns an open attempt is parked: only an explicit captain reassignment
  * may rotate that capability. Automatic retry is reserved for cold recovery,
- * when the durable owner is no longer resident in the live Agent registry.
+ * when this process has not observed the durable owner settle its open attempt.
  * @module dsh-agent-teams/scheduler
  */
 
@@ -65,6 +65,12 @@ export interface DispatchTicket {
   readonly attempt: number
   readonly attemptId: string
   readonly previousAssignee?: string
+  /** True when this ticket rotates an unobserved durable open attempt. */
+  readonly recoveredOwned: boolean
+  /** Original task generation, used to restore a failed automatic recovery. */
+  readonly previousStatus?: 'claimed' | 'in_progress'
+  readonly previousAttempt?: number
+  readonly previousAttemptId?: string
   readonly subject: string
   readonly description?: string
   readonly teamDescription?: string
@@ -338,20 +344,14 @@ export function installTeamScheduler(ctx: Context, config: SchedulerConfig): Tea
           const currentMember = fresh.members.find(candidate => candidate.name === memberName && candidate.status !== 'removed')
           if (currentMember === undefined || currentMember.id === '' || !isMemberAvailable(ctx, currentMember)) return undefined
           const owned = ownedOpenTask(fresh.tasks, currentMember.name)
-          // A resident idle member can intentionally leave an attempt open
-          // while waiting for guidance, or because the user paused its turn.
-          // Re-dispatching here would revoke still-valid work on every idle
-          // edge and every status kick. A parked attempt is therefore kept
-          // only while its owner remains resident in the live Agent registry.
-          // Once that member has disappeared, the prior turn cannot receive a
-          // follow-up, so retaining the process-local parking marker would
-          // make the durable claimed/in-progress task permanently ownerless.
+          // An idle edge observed by this scheduler parks the exact open
+          // capability. Harness may dispose its AgentHandle after settlement,
+          // so registry absence is not evidence that the owner was lost. Keep
+          // the marker sticky across later kicks; only a durable attempt that
+          // this process has not observed is eligible for one cold recovery.
           const parkedAttemptId = parkedAttempts.get(currentMember.id)
-          const ownerIsResident = liveMember(ctx, currentMember) !== undefined
           const recoverOwned = owned !== undefined
-            && (owned.attemptId === undefined
-              || owned.attemptId !== parkedAttemptId
-              || !ownerIsResident)
+            && (owned.attemptId === undefined || owned.attemptId !== parkedAttemptId)
           const task = recoverOwned ? owned : owned === undefined
             ? nextReadyTask(fresh.tasks, currentMember.name)
             : undefined
@@ -363,8 +363,16 @@ export function installTeamScheduler(ctx: Context, config: SchedulerConfig): Tea
             return undefined
           }
           const previousAssignee = task.assignee
+          const previousStatus = recoverOwned ? task.status as 'claimed' | 'in_progress' : undefined
+          const previousAttempt = recoverOwned ? task.attempt : undefined
+          const previousAttemptId = recoverOwned ? task.attemptId : undefined
           const attemptId = beginTaskAttempt(task, currentMember.name)
-          parkedAttempts.delete(currentMember.id)
+          // A recovered generation is parked before delivery. This makes each
+          // (member, attempt) recovery idempotent even if every status poll
+          // sees a disposed handle. Fresh pending work remains unparked so a
+          // genuinely lost first delivery can be recovered once.
+          if (recoverOwned) parkedAttempts.set(currentMember.id, attemptId)
+          else parkedAttempts.delete(currentMember.id)
           currentMember.status = 'working'
           await writeTeam(stateRoot, fresh)
           const profileSeedId = taskProfileSeedId(task)
@@ -376,6 +384,10 @@ export function installTeamScheduler(ctx: Context, config: SchedulerConfig): Tea
             attempt: task.attempt ?? 1,
             attemptId,
             previousAssignee,
+            recoveredOwned: recoverOwned,
+            ...previousStatus === undefined ? {} : { previousStatus },
+            ...previousAttempt === undefined ? {} : { previousAttempt },
+            ...previousAttemptId === undefined ? {} : { previousAttemptId },
             subject: task.subject,
             description: task.description,
             teamDescription: fresh.description,
@@ -417,9 +429,21 @@ export function installTeamScheduler(ctx: Context, config: SchedulerConfig): Tea
           if (fresh === undefined) return
           const task = fresh.tasks.find(candidate => candidate.id === ticket.taskId)
           if (task?.attemptId !== ticket.attemptId) return
-          task.status = 'pending'
-          task.assignee = ticket.previousAssignee
-          task.attemptId = undefined
+          if (ticket.recoveredOwned && ticket.previousStatus !== undefined && ticket.previousAttemptId !== undefined) {
+            // Recovery delivery failed. Restore the durable generation instead
+            // of returning it to pending, then keep it parked so later status
+            // kicks cannot spend an unbounded sequence of fresh attempts.
+            task.status = ticket.previousStatus
+            task.assignee = ticket.previousAssignee
+            task.attempt = ticket.previousAttempt
+            task.attemptId = ticket.previousAttemptId
+            parkedAttempts.set(ticket.memberId, ticket.previousAttemptId)
+          } else {
+            task.status = 'pending'
+            task.assignee = ticket.previousAssignee
+            task.attemptId = undefined
+            parkedAttempts.delete(ticket.memberId)
+          }
           task.handoffId = undefined
           task.reassigning = false
           task.updatedAt = Date.now()

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -341,13 +341,17 @@ export function installTeamScheduler(ctx: Context, config: SchedulerConfig): Tea
           // A resident idle member can intentionally leave an attempt open
           // while waiting for guidance, or because the user paused its turn.
           // Re-dispatching here would revoke still-valid work on every idle
-          // edge and every status kick. The idle observer remembers that exact
-          // capability across normal continuable disposal; only an unobserved
-          // durable capability (cold process recovery) or a legacy open task
-          // with no capability is retried.
+          // edge and every status kick. A parked attempt is therefore kept
+          // only while its owner remains resident in the live Agent registry.
+          // Once that member has disappeared, the prior turn cannot receive a
+          // follow-up, so retaining the process-local parking marker would
+          // make the durable claimed/in-progress task permanently ownerless.
           const parkedAttemptId = parkedAttempts.get(currentMember.id)
+          const ownerIsResident = liveMember(ctx, currentMember) !== undefined
           const recoverOwned = owned !== undefined
-            && (owned.attemptId === undefined || owned.attemptId !== parkedAttemptId)
+            && (owned.attemptId === undefined
+              || owned.attemptId !== parkedAttemptId
+              || !ownerIsResident)
           const task = recoverOwned ? owned : owned === undefined
             ? nextReadyTask(fresh.tasks, currentMember.name)
             : undefined


### PR DESCRIPTION
## 问题背景

在实际 AgentTeams 任务中观察到以下永久停滞状态：

- 团队仍有 `claimed` / `in_progress` 任务，因此 Web 面板持续显示“进行中”；
- 所有成员都已显示 idle，且任务所属成员已不在 Harness 的 live Agent registry 中；
- 后续调用 `agent_teams_status` 仍不会重新唤醒该成员，任务也不会进入终态。

根因是 scheduler 使用进程内 `parkedAttempts` 记录成员在 idle 边缘仍持有的 attempt。这个机制用于保护“成员主动暂停、等待 Captain 指示”的有效任务，避免每次 status kick 都撤销并重派。但原实现仅比较持久化的 `attemptId` 与 `parkedAttempts`，没有同时确认 attempt 所属成员是否仍存在于 live Agent registry。成员的 AgentHandle 消失后，parking marker 仍会无限期阻止恢复，形成没有运行 Agent 的永久进行中任务。

## 修改内容

### 1. 区分 resident parking 与 abandoned parking

在 `src/scheduler.ts` 的 owned-open-task 恢复判断中增加 live registry residency 检查：

- **成员仍 resident 且 idle**：保持已有 attempt，不重新派发。这保留暂停/等待指导语义，并避免重复模型回合。
- **成员不再 resident**：把该 parked attempt 视为已失联；下次 Captain status check 或 scheduler kick 使用 `beginTaskAttempt` 创建新 attempt，并重新唤醒原成员。

新 attempt 会递增单调 `attempt` 并产生新的 `attemptId`，因此旧回合的迟到更新仍会被 stale-attempt 机制拒绝，不会覆盖恢复后的结果。

### 2. 增加生命周期回归测试

在 `scripts/lifecycle-verify.mjs` 中覆盖两个相邻但语义不同的场景：

1. resident idle owner 持有 `in_progress` 任务时，多次并发调用 `agent_teams_status`：
   - attempt 和 attemptId 保持不变；
   - 不产生额外 delivery；
   - 证明本修复不会破坏显式暂停/等待指导行为。
2. 同一 parked owner 随后从 live Agent registry 消失，再调用 Captain status：
   - 任务重新进入 `claimed`；
   - 仍分配给原成员；
   - attempt 递增；
   - attemptId 更新；
   - 产生一次新的唤醒 delivery。

同时调整后续 reassignment 断言，使其验证从“恢复后的 attempt”安全转派，而不是依赖恢复前的旧 generation。

### 3. 更新使用文档

在 `docs/usage.md` 补充调度语义：resident 成员的 open attempt 会停驻；成员离开 live registry 后，下一次 Captain 状态检查或 scheduler kick 会建立新 attempt 并重新唤醒成员，避免团队永久显示进行中但没有 Agent 执行。

## 为什么采用该方案

- 不使用固定时间超时，避免长任务、用户暂停或等待 Captain 指导时被误判并重复执行。
- 使用 Harness live Agent registry 作为当前进程中成员是否仍可继续原回合的权威信号，与现有 `isMemberAvailable` / activity projection 语义一致。
- 继续复用现有 `beginTaskAttempt` capability rotation，保留并发安全和迟到写入防护。
- 修复范围仅限 scheduler 的恢复条件，不修改持久化 schema，也不需要迁移既有 `team.json`。

## 测试与验证

在基于官方最新 `main`（0.1.14，`5fe388f`）的分支上执行并通过：

- `pnpm install`
- `pnpm build`
  - Host TypeScript 编译通过；
  - Client TypeScript 编译通过；
  - tsdown client bundle 构建通过。
- `pnpm typecheck`
  - Host 与 Client 两个 TypeScript program 均通过。
- `pnpm verify`
  - offline verification 全部通过；
  - fallback TDD 全部通过；
  - quality-gates TDD 全部通过；
  - lifecycle verification 全部通过，包含新增的 parked-owner recovery 回归场景；
  - stress verification 全部通过；
  - Skill 镜像一致性验证通过。
- `git diff --check` 通过。

关键新增测试结果：

- `PASS resident idle owner keeps its open attempt across repeated scheduler kicks`
- `PASS missing parked owner is redispatched with a fresh attempt`
- `PASS reassignment quiesces recovered owner and creates a new attempt`
- `PASS old member cannot publish a late takeover result`

## 变更文件

- `src/scheduler.ts`
- `scripts/lifecycle-verify.mjs`
- `docs/usage.md`

