### PR TITLE
fix(tools): align agent_teams_status description with no-busy-poll protocol

### DIFF
--- a/src/tools.ts
+++ b/src/tools.ts
@@ -1838,7 +1838,7 @@ export function registerAgentTeamsTools(ctx: Context, config: ToolsConfig): Agen
 
   ctx.tools.register(defineTool({
     name: 'agent_teams_status',
-    description: 'Team snapshot: members with live activity and tasks with status/assignee/dependencies/output. Captains also see every team mailbox; members see only their own inbox. Poll this to watch progress.',
+    description: 'Team snapshot: members with live activity and tasks with status/assignee/dependencies/output. Captains also see every team mailbox; members see only their own inbox. Members receive work via scheduler wakeups and report through the mailbox. Dispatch, then end your turn — you will be woken by progress deliveries; avoid polling while members are running.',
     parameters: {},
     output: {
       schema: { type: 'object', additionalProperties: true, properties: {} },


### PR DESCRIPTION
Refs #78（队长会话内高频轮询的定位与讨论）。

`agent_teams_status` 的工具描述以 "Poll this to watch progress." 收尾，与 usage prompt 第 6 条的 do not busy-poll 相抵；两条指示同时进上下文时，长任务期间模型容易漂向反复调用 status。

本 PR 仅将描述末句替换为事件驱动的等待指引（成员由调度器唤醒、经邮箱回报——派活后结束回合即可），其余一字未动：

> Members receive work via scheduler wakeups and report through the mailbox. Dispatch, then end your turn — you will be woken by progress deliveries; avoid polling while members are running.

验证说明：仅改动一个字符串字面量；本地环境缺 DSH 内部 peer 无法执行完整 `pnpm build && pnpm verify`，请以维护者侧链路为准。