### PR TITLE
fix(build): make clean guard Windows-safe

### DIFF
--- a/scripts/clean-build.mjs
+++ b/scripts/clean-build.mjs
@@ -1,5 +1,5 @@
 import { rm } from 'node:fs/promises'
-import { dirname, join } from 'node:path'
+import { basename, dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const projectRoot = dirname(dirname(fileURLToPath(import.meta.url)))
@@ -7,7 +7,7 @@ const buildOutput = join(projectRoot, 'lib')
 
 // Keep the destructive target explicit and scoped to this package. Stale
 // compiler output otherwise survives source deletions and leaks into npm packs.
-if (dirname(buildOutput) !== projectRoot || !buildOutput.endsWith('/lib')) {
+if (dirname(buildOutput) !== projectRoot || basename(buildOutput) !== 'lib') {
   throw new Error(`refusing to clean unexpected build output: ${buildOutput}`)
 }
 


### PR DESCRIPTION
Fixes #89.

## Cause
The cleanup guard compared a Windows path against the POSIX-only suffix `/lib`, so a valid `<projectRoot>\lib` target was rejected before every build.

## Fix
Use Node's path.basename for the final segment while preserving the independent exact-parent check. The recursive target remains `join(projectRoot, 'lib')`.

## Safety proof
- Exact Windows project-root/lib path: prior base rejects; this head accepts.
- Nested, sibling, `glib`, and `lib.evil` candidates all remain rejected because both exact parent and exact basename must match.
- A Windows junction check removed only the junction entry and preserved the external target sentinel.
- Independent security diff review: zero findings.

## Verification
- pnpm build
- pnpm typecheck
- full repository verification and 38-task stress/fault-recovery suite
- skill mirror verification
- pnpm pack --dry-run
- git diff --check

Only `scripts/clean-build.mjs` changes (2 insertions, 2 deletions).