### PR TITLE
fix(client): use uiConversation for card registration

### DIFF
--- a/.dsh/skills/dsh-plugin-development/SKILL.md
+++ b/.dsh/skills/dsh-plugin-development/SKILL.md
@@ -242,7 +242,7 @@ export function apply(ctx: ClientContext): void {}
 Conversation Node 是“事件折叠 + keyed slot renderer”的组合：
 
 1. 定义共享事件类型，并 merge 到 session event map。
-2. `conversationEvents.register(definition)`：
+2. 将 `uiConversation` 放入 `inject`，并调用 `ctx.get('uiConversation').events.register(definition)`：
    - `match` 选择事件；
    - `start` 创建节点状态；
    - `update` 按 seq 确定性折叠；

--- a/docs/developing-dsh-plugins.md
+++ b/docs/developing-dsh-plugins.md
@@ -448,7 +448,7 @@ export const myDefinition: ConversationNodeDefinition<MyState> = {
 
 ```tsx
 // index.tsx 注册
-ctx.conversationEvents.register(myDefinition)
+ctx.get('uiConversation').events.register(myDefinition)
 ctx.slots.inject('conversation.chat.node', () => ctx.slots.register({
   name: 'conversation.chat.node', key: 'my-plugin',
   inject: () => ({ openSession: (id) => ctx.sessions.open(id) }),

--- a/scripts/verify.mjs
+++ b/scripts/verify.mjs
@@ -207,9 +207,10 @@ check(
       === JSON.stringify(placeholders(agentTeamsEn[key]))),
 )
 check(
-  'client registers the official locale namespace on both visible slots',
+  'client uses the uiConversation event registry and registers the official locale namespace',
   AGENT_TEAMS_LOCALE_NAMESPACE === 'agentTeams'
-    && clientIndexSource.includes("'conversationEvents', 'slots', 'sessions', 'locale', 'modelDirectories'")
+    && clientIndexSource.includes("'uiConversation', 'slots', 'sessions', 'locale', 'modelDirectories'")
+    && clientIndexSource.includes("ctx.get('uiConversation').events.register(agentTeamsCardDefinition)")
     && clientIndexSource.includes('ctx.locale.register(AGENT_TEAMS_LOCALE_NAMESPACE, { zh, en })')
     && clientIndexSource.match(/locale:\s*AGENT_TEAMS_LOCALE_NAMESPACE/gu)?.length === 2,
 )

--- a/skills/dsh-plugin-development/SKILL.md
+++ b/skills/dsh-plugin-development/SKILL.md
@@ -242,7 +242,7 @@ export function apply(ctx: ClientContext): void {}
 Conversation Node 是“事件折叠 + keyed slot renderer”的组合：
 
 1. 定义共享事件类型，并 merge 到 session event map。
-2. `conversationEvents.register(definition)`：
+2. 将 `uiConversation` 放入 `inject`，并调用 `ctx.get('uiConversation').events.register(definition)`：
    - `match` 选择事件；
    - `start` 创建节点状态；
    - `update` 按 seq 确定性折叠；

--- a/src/client/index.tsx
+++ b/src/client/index.tsx
@@ -29,7 +29,7 @@ declare module '@deepseek-ai/dsh-client-ui-slots' {
 }
 
 /** Required services: conversation nodes, slots, sessions navigation, and locale. */
-export const inject = ['conversationEvents', 'slots', 'sessions', 'locale', 'modelDirectories']
+export const inject = ['uiConversation', 'slots', 'sessions', 'locale', 'modelDirectories']
 
 /** The replayed user message is the canonical transcript entry. */
 function HiddenAgentTeamsCommand(): null {
@@ -75,7 +75,7 @@ export function apply(ctx: ClientContext): void {
     key: 'agent-teams',
   }, HiddenAgentTeamsCommand))
 
-  ctx.conversationEvents.register(agentTeamsCardDefinition)
+  ctx.get('uiConversation').events.register(agentTeamsCardDefinition)
   ctx.slots.inject('conversation.chat.node', () => ctx.slots.register({
     name: 'conversation.chat.node',
     key: 'agent-teams',


### PR DESCRIPTION
Fixes #92.

## Root cause

The browser entry still declared and used the removed `conversationEvents` service. Current DSH provides the conversation event registry through the injected `uiConversation` service, so the client fiber stayed pending with `waiting for service: conversationEvents`.

## Changes

- Inject `uiConversation` in the browser entry.
- Register the AgentTeams conversation definition through `ctx.get('uiConversation').events`. The dynamic lookup is intentional: the currently published DSH npm typings still expose the legacy Context shape, while the current DSH source/runtime exposes `uiConversation`.
- Add a regression assertion covering both the injected service and event registry call.
- Update the plugin development documentation and generated skill mirror.

## Verification

- `pnpm typecheck`
- `pnpm exec tsc -p tsconfig.json && pnpm exec tsc -p tsconfig.client.json && pnpm exec tsdown`
- `pnpm exec node scripts/fallback-tdd.mjs`
- `pnpm exec node scripts/quality-gates-tdd.mjs`
- `pnpm exec node scripts/stress-verify.mjs`
- `pnpm verify:skill`
- Built bundle contains `uiConversation` and no `conversationEvents`.
- GitNexus staged change audit: 5 files, 7 symbols, 0 affected processes, low risk.

`pnpm build` is blocked before compilation by the existing Windows path guard in `scripts/clean-build.mjs` (tracked separately by PR #90). The aggregate `pnpm verify` reaches and passes the new #92 assertion, then reports an existing transient Windows archive-lock failure; the standalone lifecycle gate also reports two unrelated existing state-machine failures.