### PR TITLE
fix: 将模型物化的空串可选字段归一为省略（#105 / #99）

### DIFF
--- a/scripts/quality-gates-tdd.mjs
+++ b/scripts/quality-gates-tdd.mjs
@@ -80,6 +80,7 @@ function loadStateApi() {
     qualityPlanningPrompt: state.qualityPlanningPrompt,
     sanitizeReviewAcceptance: state.sanitizeReviewAcceptance,
     sanitizeReviewObjective: state.sanitizeReviewObjective,
+    normalizeBlankOptionalTaskFields: state.normalizeBlankOptionalTaskFields,
     describeQualityLoop: state.describeQualityLoop,
   }
 }
@@ -168,6 +169,40 @@ console.log('quality-gates TDD — A. create contract')
   check(
     'tdd.create.work-kind-remains-compatible',
     created?.ok === true && (created.task?.kind === 'work' || created.kind === 'work'),
+  )
+}
+
+console.log('quality-gates TDD — A2. blank optional normalization (#99/#105)')
+
+{
+  const normalized = api.normalizeBlankOptionalTaskFields?.({
+    kind: 'repair',
+    subject: 'repair with blanks',
+    objective: '',
+    reviewedTaskId: '',
+    sourceTaskId: 't1',
+    sourceFindingIds: [''],
+    inScope: ['', 'src/repair.ts'],
+    acceptance: ['fixed'],
+  })
+  check(
+    'tdd.normalize.blank-optional-fields-to-omitted',
+    normalized?.reviewedTaskId === undefined
+      && normalized?.objective === undefined
+      && normalized?.sourceFindingIds === undefined
+      && JSON.stringify(normalized?.inScope) === JSON.stringify(['src/repair.ts'])
+      && normalized?.sourceTaskId === 't1'
+      && JSON.stringify(normalized?.acceptance) === JSON.stringify(['fixed']),
+  )
+  const untouched = api.normalizeBlankOptionalTaskFields?.({
+    reviewedTaskId: 't1',
+    inScope: ['src/b.ts'],
+    subject: 's',
+  })
+  check(
+    'tdd.normalize.non-blank-values-untouched',
+    untouched?.reviewedTaskId === 't1'
+      && JSON.stringify(untouched?.inScope) === JSON.stringify(['src/b.ts']),
   )
 }
 
@@ -1005,6 +1040,71 @@ console.log('quality-gates TDD — tool-level closed loop')
     check(
       'tdd.create.work-kind-remains-compatible.tool',
       persistedWork?.kind === 'work' || persistedWork?.kind === undefined,
+    )
+
+    // Regression for #105: a model-materialized reviewedTaskId:"" (plus other
+    // blank optionals) on a repair task must be normalized to omitted instead
+    // of persisted into team.json, where durable-state validation would brick
+    // the whole team on reload.
+    const repair = await call('agent_teams_create_task', {
+      subject: 'repair with blank optional',
+      kind: 'repair',
+      sourceTaskId: work.task_id,
+      sourceFindingIds: ['F-1'],
+      reviewedTaskId: '',
+      objective: 'Close F-1',
+      acceptance: ['F-1 fixed'],
+      inScope: ['', 'src/repair.ts'],
+      verify: ['', 'pnpm verify'],
+    })
+    const persistedRepair = (await readTeam(join(workspace, '.agent-teams'), 'gates'))?.tasks.find((item) => item.id === repair.task_id)
+    check(
+      'tdd.create.blank-optional-fields-normalized.tool',
+      persistedRepair?.reviewedTaskId === undefined
+        && persistedRepair?.objective === 'Close F-1'
+        && JSON.stringify(persistedRepair?.inScope) === JSON.stringify(['src/repair.ts'])
+        && JSON.stringify(persistedRepair?.verify) === JSON.stringify(['pnpm verify']),
+    )
+    check(
+      'tdd.create.team-still-loadable-after-blank-optional.tool',
+      (await readTeam(join(workspace, '.agent-teams'), 'gates'))?.id === 'gates',
+    )
+    await throwsAsync('tdd.create.review-blank-reviewedTaskId-rejected.tool', () => call('agent_teams_create_task', {
+      subject: 'review blank id',
+      kind: 'review',
+      objective: 'Review it',
+      acceptance: ['pass'],
+      reviewedTaskId: '',
+    }))
+
+    // Regression for #99: a blank optional profile must be treated as omitted,
+    // not as a hard create failure.
+    const blankProfileCaptain = {
+      id: 'captain-session-blank-profile',
+      status: 'idle',
+      options: { provider: 'fake', model: 'fake-model' },
+      session: {
+        header: { cwd: workspace, seedLength: 0 },
+        events: [],
+        append() {},
+        requestHeader() {
+          return { config: { provider: 'fake', model: 'fake-model', reasoningEffort: 'high' } }
+        },
+      },
+      followup() {},
+      steer() {},
+      cancel() {},
+      whenIdle() { return Promise.resolve() },
+    }
+    liveAgents.set(blankProfileCaptain.id, blankProfileCaptain)
+    const blankProfileTeam = await call(
+      'agent_teams_create',
+      { name: 'Blank Profile', profile: '' },
+      blankProfileCaptain,
+    )
+    check(
+      'tdd.create.blank-profile-treated-as-omitted.tool',
+      typeof blankProfileTeam?.team_id === 'string' && blankProfileTeam?.profile === undefined,
     )
 
     await throwsAsync('tdd.create.implementation-requires-objective.tool', () => call('agent_teams_create_task', {

--- a/scripts/quality-gates-tdd.mjs
+++ b/scripts/quality-gates-tdd.mjs
@@ -204,6 +204,17 @@ console.log('quality-gates TDD — A2. blank optional normalization (#99/#105)')
     untouched?.reviewedTaskId === 't1'
       && JSON.stringify(untouched?.inScope) === JSON.stringify(['src/b.ts']),
   )
+  for (const invalid of [123, null, { path: 'src/private/' }]) {
+    const malformed = task({ acceptance: ['', invalid, 'real criterion'] })
+    const normalized = api.normalizeBlankOptionalTaskFields?.(malformed)
+    check(
+      `tdd.normalize.retains-invalid-list-item.${JSON.stringify(invalid)}`,
+      normalized?.acceptance?.length === 2
+        && normalized.acceptance[0] === invalid
+        && api.isTeamTask?.(normalized) === false
+        && malformed.acceptance.length === 3,
+    )
+  }
 }
 
 function rejectCreate(label, current, input, extraOk) {

--- a/scripts/verify.mjs
+++ b/scripts/verify.mjs
@@ -525,6 +525,55 @@ try {
     recovered?.id === dirty.id && recovered.profile === undefined && recovered.tasks[0]?.profileSeedId === undefined)
   await removeTeamDir(stateRoot, dirty.id)
 
+  // Regression for #105: a task persisted with model-materialized blank
+  // optional fields (e.g. reviewedTaskId:"") used to brick the whole team on
+  // reload. The durable boundary must normalize blanks to omitted instead,
+  // while keeping non-blank optional values intact.
+  const dirtyQuality = {
+    ...team,
+    id: 'dirty-quality-fields',
+    tasks: [
+      {
+        id: 't1',
+        subject: 'Review impl',
+        kind: 'review',
+        status: 'pending',
+        dependencies: [],
+        reviewedTaskId: 't2',
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      },
+      {
+        id: 't2',
+        subject: 'Repair with blanks',
+        kind: 'repair',
+        status: 'pending',
+        dependencies: [],
+        sourceTaskId: 't1',
+        sourceFindingIds: [''],
+        reviewedTaskId: '',
+        objective: '',
+        inScope: ['', 'src/repair.ts'],
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      },
+    ],
+    taskSeq: 2,
+  }
+  await mkdir(join(stateRoot, dirtyQuality.id, 'inbox'), { recursive: true })
+  await writeFile(join(stateRoot, dirtyQuality.id, 'team.json'), JSON.stringify(dirtyQuality, null, 2), 'utf8')
+  const recoveredQuality = await readTeam(stateRoot, dirtyQuality.id)
+  const repairedTask = recoveredQuality?.tasks.find((item) => item.id === 't2')
+  check('cold-resume recovers blank optional quality fields (#105)',
+    recoveredQuality?.id === dirtyQuality.id
+      && repairedTask?.reviewedTaskId === undefined
+      && repairedTask?.objective === undefined
+      && repairedTask?.sourceFindingIds === undefined
+      && JSON.stringify(repairedTask?.inScope) === JSON.stringify(['src/repair.ts']))
+  check('cold-resume keeps non-blank optional quality fields (#105)',
+    recoveredQuality?.tasks.find((item) => item.id === 't1')?.reviewedTaskId === 't2')
+  await removeTeamDir(stateRoot, dirtyQuality.id)
+
   const found = await findTeamByCaptain(stateRoot, 'sess-captain')
   check('findTeamByCaptain finds the team', found?.id === team.id)
   check('findTeamByCaptain ignores other captains', await findTeamByCaptain(stateRoot, 'sess-other') === undefined)

--- a/scripts/verify.mjs
+++ b/scripts/verify.mjs
@@ -574,6 +574,26 @@ try {
     recoveredQuality?.tasks.find((item) => item.id === 't1')?.reviewedTaskId === 't2')
   await removeTeamDir(stateRoot, dirtyQuality.id)
 
+  // Recovery only removes blank strings. Other malformed values must still
+  // fail durable validation rather than silently erasing contract/scope data.
+  for (const [field, values] of [
+    ['acceptance', [123, 'real criterion']],
+    ['outOfScope', [{ path: 'src/private/' }]],
+    ['sourceFindingIds', [null]],
+  ]) {
+    const malformed = {
+      ...dirtyQuality,
+      id: `malformed-${field.toLowerCase()}`,
+      tasks: [{ ...dirtyQuality.tasks[1], [field]: values }],
+    }
+    await createTeamDir(stateRoot, malformed)
+    let rejected = false
+    try { await readTeam(stateRoot, malformed.id) }
+    catch (error) { rejected = /invalid AgentTeams state/.test(String(error)) }
+    check(`cold-resume rejects non-string ${field} items`, rejected)
+    await removeTeamDir(stateRoot, malformed.id)
+  }
+
   const found = await findTeamByCaptain(stateRoot, 'sess-captain')
   check('findTeamByCaptain finds the team', found?.id === team.id)
   check('findTeamByCaptain ignores other captains', await findTeamByCaptain(stateRoot, 'sess-other') === undefined)

--- a/src/quality-gates.ts
+++ b/src/quality-gates.ts
@@ -763,6 +763,48 @@ export function isCommandResult(value: unknown): value is CommandResult {
     && (value['evidence'] === undefined || typeof value['evidence'] === 'string')
 }
 
+// Optional fields whose persisted values must be non-empty when present
+// (mirrors the checks in hasValidQualityTaskFields). Some models materialize
+// optional tool parameters as "" instead of omitting them (e.g. GPT-5.6
+// sending reviewedTaskId:"" or profile:""), which would otherwise be written
+// to team.json and then brick the whole team state on reload.
+const BLANK_SENSITIVE_STRING_FIELDS = ['objective', 'reviewedTaskId', 'sourceTaskId'] as const
+const BLANK_SENSITIVE_STRING_LIST_FIELDS = [
+  'inScope',
+  'outOfScope',
+  'acceptance',
+  'verify',
+  'deliverables',
+  'nonGoals',
+  'changedPaths',
+  'sourceFindingIds',
+  'coverageOf',
+] as const
+
+/**
+ * Normalize blank optional task fields to omitted ("blank means absent").
+ * Blank string scalars are deleted; string lists have blank entries filtered
+ * out, and a list that only contained blanks is omitted entirely. Non-blank
+ * values and every other field are passed through untouched, so durable-state
+ * validation stays strict.
+ */
+export function normalizeBlankOptionalTaskFields<T extends object>(task: T): T {
+  const next = { ...task } as Record<string, unknown>
+  for (const key of BLANK_SENSITIVE_STRING_FIELDS) {
+    const value = next[key]
+    if (typeof value === 'string' && value.trim() === '') delete next[key]
+  }
+  for (const key of BLANK_SENSITIVE_STRING_LIST_FIELDS) {
+    const value = next[key]
+    if (!Array.isArray(value)) continue
+    const kept = value.filter((item) => typeof item === 'string' && item.trim() !== '')
+    if (kept.length === value.length) continue
+    if (kept.length === 0) delete next[key]
+    else next[key] = kept
+  }
+  return next as T
+}
+
 export function hasValidQualityTaskFields(value: Record<string, unknown>): boolean {
   if (value['kind'] !== undefined && !(TASK_KINDS as readonly string[]).includes(value['kind'] as string)) return false
   if (value['verdict'] !== undefined && !(REVIEW_VERDICTS as readonly string[]).includes(value['verdict'] as string)) return false

--- a/src/quality-gates.ts
+++ b/src/quality-gates.ts
@@ -797,7 +797,7 @@ export function normalizeBlankOptionalTaskFields<T extends object>(task: T): T {
   for (const key of BLANK_SENSITIVE_STRING_LIST_FIELDS) {
     const value = next[key]
     if (!Array.isArray(value)) continue
-    const kept = value.filter((item) => typeof item === 'string' && item.trim() !== '')
+    const kept = value.filter((item) => !(typeof item === 'string' && item.trim() === ''))
     if (kept.length === value.length) continue
     if (kept.length === 0) delete next[key]
     else next[key] = kept

--- a/src/state.ts
+++ b/src/state.ts
@@ -18,7 +18,7 @@ import { readFileSync } from 'node:fs'
 import { mkdir, readFile, readdir, rename, rm, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { TERMINAL_TASK_STATUSES, type TaskStatus, type TeamMember, type TeamMessage, type TeamProfileSnapshot, type TeamState, type TeamTask } from './types.ts'
-import { hasValidQualityTaskFields, isReviewPolicy } from './quality-gates.ts'
+import { hasValidQualityTaskFields, isReviewPolicy, normalizeBlankOptionalTaskFields } from './quality-gates.ts'
 
 export {
   buildCoverageMatrix,
@@ -30,6 +30,7 @@ export {
   evaluateQualityCompletion,
   hasValidQualityTaskFields,
   isQualityKind,
+  normalizeBlankOptionalTaskFields,
   pathMatchesScope,
   planQualityFollowUp,
   qualityPlanningPrompt,
@@ -730,12 +731,17 @@ function coerceTeamState(value: unknown, expectedId: string): TeamState | undefi
   }
   const tasks = (value['tasks'] as unknown[]).map((task) => {
     if (!isRecord(task)) return task
-    if (task['profileSeedId'] !== undefined && (typeof task['profileSeedId'] !== 'string' || task['profileSeedId'].trim() === '')) {
-      const next = { ...task }
+    // Tolerate legacy dirty records instead of bricking the whole team on
+    // reload: blank optional fields written by older builds (or by models that
+    // materialize optionals as "") are normalized to omitted, matching the
+    // profileSeedId handling below and the tool-input normalization.
+    const cleaned = normalizeBlankOptionalTaskFields(task)
+    if (cleaned['profileSeedId'] !== undefined && (typeof cleaned['profileSeedId'] !== 'string' || cleaned['profileSeedId'].trim() === '')) {
+      const next = { ...cleaned }
       delete next['profileSeedId']
       return next
     }
-    return task
+    return cleaned
   })
   const coerced = { ...value, tasks }
   return isTeamState(coerced, expectedId) ? coerced : undefined

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -49,6 +49,7 @@ import {
   describeQualityLoop,
   sanitizeReviewAcceptance,
   sanitizeReviewObjective,
+  normalizeBlankOptionalTaskFields,
   taskKindOf,
 } from './state.ts'
 import type { AcceptanceResult, CommandResult, ReviewFinding, ReviewVerdict, TaskKind } from './types.ts'
@@ -723,10 +724,12 @@ export function registerAgentTeamsTools(ctx: Context, config: ToolsConfig): Agen
       if (teamName === '') throw new Error('team name must not be empty')
       const teamId = sanitizeKey(teamName)
       const staged = args.approval === 'required'
-      const profileName = args.profile?.trim()
-      if (args.profile !== undefined && profileName === '') {
-        throw new Error('AgentTeams profile name must not be empty')
-      }
+      // Some models materialize optional parameters as "" instead of omitting
+      // them (issue #99). The profile is optional, so treat a blank value
+      // exactly like an omitted one instead of failing every create call.
+      const profileName = args.profile !== undefined && args.profile.trim() !== ''
+        ? args.profile.trim()
+        : undefined
       const created = await withTeamLock(captainLockKey(stateRoot, captain.id), async () => {
         const current = await findTeamByParticipant(stateRoot, captain.id)
         if (current !== undefined) {
@@ -1222,28 +1225,33 @@ export function registerAgentTeamsTools(ctx: Context, config: ToolsConfig): Agen
       const workspace = workspaceOf(captain)
       const stateRoot = stateRootOf(workspace, config)
       const team = await requireCaptainTeam(workspace, config, captain)
+      // Some models materialize optional parameters as "" instead of omitting
+      // them (issue #105). Normalize blank optional fields to omitted before
+      // validation so a blank value can neither be rejected spuriously nor be
+      // persisted into team.json, where it would brick the team on reload.
+      const input = normalizeBlankOptionalTaskFields(args)
       const created = await withTeamLock(teamLockKey(stateRoot, team.id), async () => {
         const fresh = await requireFreshCaptainTeam(stateRoot, team.id, captain.id)
         const gate = validateCreateTask(fresh, {
-          subject: args.subject,
-          description: args.description,
-          dependencies: args.dependencies,
-          assignee: args.assignee,
-          kind: args.kind as TaskKind | undefined,
-          round: args.round,
-          objective: args.objective,
-          inScope: args.inScope,
-          outOfScope: args.outOfScope,
-          acceptance: args.acceptance,
-          verify: args.verify,
-          deliverables: args.deliverables,
-          nonGoals: args.nonGoals,
-          reviewedTaskId: args.reviewedTaskId,
-          sourceTaskId: args.sourceTaskId,
-          sourceFindingIds: args.sourceFindingIds,
-          coverageOf: args.coverageOf,
-          resume: args.resume,
-          resumeReason: args.resumeReason,
+          subject: input.subject,
+          description: input.description,
+          dependencies: input.dependencies,
+          assignee: input.assignee,
+          kind: input.kind as TaskKind | undefined,
+          round: input.round,
+          objective: input.objective,
+          inScope: input.inScope,
+          outOfScope: input.outOfScope,
+          acceptance: input.acceptance,
+          verify: input.verify,
+          deliverables: input.deliverables,
+          nonGoals: input.nonGoals,
+          reviewedTaskId: input.reviewedTaskId,
+          sourceTaskId: input.sourceTaskId,
+          sourceFindingIds: input.sourceFindingIds,
+          coverageOf: input.coverageOf,
+          resume: input.resume,
+          resumeReason: input.resumeReason,
         })
         if (!gate.ok) throw new Error(gate.error ?? 'create_task rejected by quality gates')
         if (fresh.halted === true) {
@@ -1267,11 +1275,11 @@ export function registerAgentTeamsTools(ctx: Context, config: ToolsConfig): Agen
         if (args.assignee !== undefined) requireMember(fresh, args.assignee)
         const kind = gate.kind ?? 'work'
         const objective = kind === 'review' || kind === 'requirements'
-          ? sanitizeReviewObjective(args.objective)
-          : args.objective
+          ? sanitizeReviewObjective(input.objective)
+          : input.objective
         const acceptance = kind === 'review' || kind === 'requirements'
-          ? sanitizeReviewAcceptance(args.acceptance)
-          : args.acceptance
+          ? sanitizeReviewAcceptance(input.acceptance)
+          : input.acceptance
         const task: TeamTask = {
           id: `t${fresh.taskSeq + 1}`,
           subject: args.subject,
@@ -1285,16 +1293,16 @@ export function registerAgentTeamsTools(ctx: Context, config: ToolsConfig): Agen
           kind,
           ...args.round === undefined ? {} : { round: args.round },
           ...objective === undefined ? {} : { objective },
-          ...args.inScope === undefined ? {} : { inScope: args.inScope },
-          ...args.outOfScope === undefined ? {} : { outOfScope: args.outOfScope },
+          ...input.inScope === undefined ? {} : { inScope: input.inScope },
+          ...input.outOfScope === undefined ? {} : { outOfScope: input.outOfScope },
           ...acceptance === undefined ? {} : { acceptance },
-          ...args.verify === undefined ? {} : { verify: args.verify },
-          ...args.deliverables === undefined ? {} : { deliverables: args.deliverables },
-          ...args.nonGoals === undefined ? {} : { nonGoals: args.nonGoals },
-          ...args.reviewedTaskId === undefined ? {} : { reviewedTaskId: args.reviewedTaskId },
-          ...args.sourceTaskId === undefined ? {} : { sourceTaskId: args.sourceTaskId },
-          ...args.sourceFindingIds === undefined ? {} : { sourceFindingIds: args.sourceFindingIds },
-          ...args.coverageOf === undefined ? {} : { coverageOf: args.coverageOf },
+          ...input.verify === undefined ? {} : { verify: input.verify },
+          ...input.deliverables === undefined ? {} : { deliverables: input.deliverables },
+          ...input.nonGoals === undefined ? {} : { nonGoals: input.nonGoals },
+          ...input.reviewedTaskId === undefined ? {} : { reviewedTaskId: input.reviewedTaskId },
+          ...input.sourceTaskId === undefined ? {} : { sourceTaskId: input.sourceTaskId },
+          ...input.sourceFindingIds === undefined ? {} : { sourceFindingIds: input.sourceFindingIds },
+          ...input.coverageOf === undefined ? {} : { coverageOf: input.coverageOf },
         }
         fresh.taskSeq += 1
         fresh.tasks.push(task)
@@ -1653,6 +1661,10 @@ export function registerAgentTeamsTools(ctx: Context, config: ToolsConfig): Agen
             ...task.output !== undefined ? { output: task.output } : {},
           }
         }
+        // Blank optional list entries (e.g. changedPaths:[""]) must not be
+        // persisted: hasValidQualityTaskFields rejects them on reload and
+        // would brick the whole team state (issue #105 class).
+        const input = normalizeBlankOptionalTaskFields(args)
         const findings = parseFindings(args.findings)
         const acceptanceResults = parseAcceptanceResults(args.acceptanceResults)
         const commandsRun = parseCommandResults(args.commandsRun)
@@ -1661,7 +1673,7 @@ export function registerAgentTeamsTools(ctx: Context, config: ToolsConfig): Agen
           output: args.output,
           verdict: args.verdict as ReviewVerdict | undefined,
           findings,
-          changedPaths: args.changedPaths,
+          changedPaths: input.changedPaths,
           acceptanceResults,
           commandsRun,
         })
@@ -1674,7 +1686,7 @@ export function registerAgentTeamsTools(ctx: Context, config: ToolsConfig): Agen
         if (args.output !== undefined) task.output = args.output
         if (args.verdict !== undefined) task.verdict = args.verdict as ReviewVerdict
         if (findings !== undefined) task.findings = findings
-        if (args.changedPaths !== undefined) task.changedPaths = args.changedPaths
+        if (input.changedPaths !== undefined) task.changedPaths = input.changedPaths
         if (acceptanceResults !== undefined) task.acceptanceResults = acceptanceResults
         if (commandsRun !== undefined) task.commandsRun = commandsRun
         task.updatedAt = Date.now()
@@ -2231,7 +2243,9 @@ function parseFindings(value: unknown): ReviewFinding[] | undefined {
       severity: raw['severity'],
       problem: raw['problem'],
       requiredFix: raw['requiredFix'],
-      ...typeof raw['file'] === 'string' ? { file: raw['file'] } : {},
+      // A blank optional file must be omitted, not persisted: durable-state
+      // validation requires non-empty optional strings (issue #105 class).
+      ...typeof raw['file'] === 'string' && raw['file'].trim() !== '' ? { file: raw['file'] } : {},
       ...typeof raw['line'] === 'number' ? { line: raw['line'] } : {},
       ...typeof raw['resolved'] === 'boolean' ? { resolved: raw['resolved'] } : {},
     }


### PR DESCRIPTION
## 问题

GPT-5.6 系列模型倾向于把可选工具参数物化为空串而不是省略（另见 OmniRoute #1674 / #6951）：

- #99：`agent_teams_create` 反复收到 `profile: ""`，触发 `AgentTeams profile name must not be empty`，建队必败。
- #105：`agent_teams_create_task` 收到 `reviewedTaskId: ""`（repair 任务），创建时通过校验并写入 team.json；但重载时 `hasValidQualityTaskFields()` 拒绝空串，`coerceTeamState()` 返回 undefined，所有 AgentTeams 操作报 `invalid AgentTeams state`——一个脏 task 使整个控制平面不可用。

## 修复

按"空串归一化为省略，不放宽校验"处理，覆盖写入与加载两端：

1. 新增 `normalizeBlankOptionalTaskFields()`（`src/quality-gates.ts`）：空白标量（`objective`/`reviewedTaskId`/`sourceTaskId`）删除；9 个可选字符串列表过滤空白项，全空则整字段省略。
2. 工具输入边界：`agent_teams_create_task` 在校验与持久化前归一输入；`agent_teams_update_task` 归一 `changedPaths`；`parseFindings` 省略空白 `file`；`agent_teams_create` 的空白 `profile` 视为未提供。
3. 加载路径：`coerceTeamState()` 对已有脏 task 应用同一归一（延续既有 `profileSeedId`/`profile` 容错先例），已被写脏的 team.json 自动恢复可读，无需人工修复。
4. 校验严格性不变：`kind=review` 仍要求非空 `reviewedTaskId`；其余非法形状仍被 durable-state 校验拒绝。

## 测试

- `scripts/verify.mjs`：脏团队（含 `reviewedTaskId:""` 等）重载恢复 + 非空可选值保留。
- `scripts/quality-gates-tdd.mjs`：归一 helper 正/反单测；工具级回归（repair + `reviewedTaskId:""` 成功且持久化干净、团队仍可读；review + 空串被正确拒绝；`profile:""` 建队成功）。
- 验证环境（Windows 11 26200 x64，Node v24.16.0，pnpm 11.21.0）：已 rebase 到 main @ da2e2e4（0.1.15，含 alpha.2 适配 bf50b49）重跑——`tsc` 零错误、verify.mjs 全绿（含两条新增 cold-resume 回归）、quality-gates-tdd / fallback-tdd / stress-verify / verify:skill 全绿。Windows 上 `pnpm build` 受 clean-build 守卫影响需另案处理（#89 / PR #90），verify 套件两处既有时序 flaky 另案（#108）。

Fixes #105
Fixes #99
