### PR TITLE
fix(members): 成员 turn 传输类失败自动置败、释放成员并通知队长（Fixes #94）

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.client.json --noEmit",
     "sync:skill": "node scripts/sync-skill.mjs",
     "verify:skill": "node scripts/sync-skill.mjs --check",
-    "verify": "node scripts/verify.mjs && node scripts/fallback-tdd.mjs && node scripts/quality-gates-tdd.mjs && node scripts/lifecycle-verify.mjs && node scripts/stress-verify.mjs && pnpm verify:web-routes && pnpm verify:release && pnpm verify:skill",
+    "verify": "node scripts/verify.mjs && node scripts/fallback-tdd.mjs && node scripts/member-failure-tdd.mjs && node scripts/quality-gates-tdd.mjs && node scripts/lifecycle-verify.mjs && node scripts/stress-verify.mjs && pnpm verify:web-routes && pnpm verify:release && pnpm verify:skill",
     "prepublishOnly": "pnpm build && pnpm verify",
     "verify:web-routes": "node scripts/web-routes-verify.mjs",
     "verify:release": "node --test scripts/release-metadata.test.mjs"
@@ -204,6 +204,7 @@
     "@deepseek-ai/dsh-client-ui-slots": "0.1.2-alpha.2",
     "@deepseek-ai/dsh-commands": "0.1.2-alpha.2",
     "@deepseek-ai/dsh-llm": "0.1.2-alpha.2",
+    "@deepseek-ai/dsh-llm-retry": "0.1.2-alpha.2",
     "@deepseek-ai/dsh-session": "0.1.2-alpha.2",
     "@deepseek-ai/dsh-session-projection": "0.1.2-alpha.2",
     "@deepseek-ai/dsh-subagent": "0.1.2-alpha.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       '@deepseek-ai/dsh-llm':
         specifier: 0.1.2-alpha.2
         version: 0.1.2-alpha.2(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-invariants@0.1.2-alpha.2(@deepseek-ai/cordis@4.0.2))
+      '@deepseek-ai/dsh-llm-retry':
+        specifier: 0.1.2-alpha.2
+        version: 0.1.2-alpha.2(949296e9c4a084c2c6c23d9ad3559882)
       '@deepseek-ai/dsh-session':
         specifier: 0.1.2-alpha.2
         version: 0.1.2-alpha.2(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-invariants@0.1.2-alpha.2(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-scope@0.1.2-alpha.2(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-invariants@0.1.2-alpha.2(@deepseek-ai/cordis@4.0.2)))

--- a/scripts/lifecycle-verify.mjs
+++ b/scripts/lifecycle-verify.mjs
@@ -11,6 +11,7 @@
 import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { LlmError } from '@deepseek-ai/dsh-llm'
 import { haltTeamWork, registerAgentTeamsTools } from '../lib/tools.js'
 import { buildActivationDirective, invokedAgentTeamsGoal, invokedAgentTeamsInvocation, installAgentTeamsGestureBoundary, profileCommandName, registerAgentTeamsCommand } from '../lib/command.js'
 import { readArchivedTeam, readMailbox, readTeam, readUnreadMailbox } from '../lib/state.js'
@@ -53,11 +54,12 @@ function makeAgent(id, parentSession) {
     options: { provider: 'fake', model: 'fake-model' },
     session: session(parentSession),
     followups: [],
+    steers: [],
     injections: [],
     followup(message) {
       this.followups.push(message)
     },
-    steer() {},
+    steer(message) { this.steers.push(message) },
     inject(message) {
       this.injections.push(message)
     },
@@ -112,9 +114,19 @@ async function emitRequestError(child, failure) {
       failure,
       retryPolicy: undefined,
       signal: new AbortController().signal,
-    })
+    }, async () => undefined)
   }
   return action
+}
+
+/** Final error followed by driver settlement, with no agent/status event. */
+function emitTurnError(child, failure) {
+  for (const handler of childListeners.get(child.id)?.get('agent/error') ?? []) {
+    handler({ agent: child, turn: 1, step: 0, error: new LlmError(failure.message, failure.code) })
+  }
+  child.status = 'idle'
+  child._idle?.()
+  child._idle = undefined
 }
 
 const captain = makeAgent('captain-session')
@@ -1181,10 +1193,8 @@ try {
   // A member turn dies mid-stream with a transport-class failure and the
   // harness emits no idle edge: the continuable handle survives and the
   // durable record keeps the member "working". The plugin must bridge the
-  // failure at the request-error boundary (fail the open attempt, release
-  // the member, notify the captain); before the fix the request-error hook
-  // was only installed when a fallback route existed, so no-fallback teams
-  // stalled silently with a parked in_progress task.
+  // failure at the final agent/error boundary. A request error may still be
+  // retried by Harness, and must not close the task prematurely.
   await call('agent_teams_create', { name: 'Failure Bridge', description: 'turn failures must surface' })
   await call('agent_teams_add_member', { name: 'flake', role: 'streaming worker' })
   const flakeTeam = await readTeam(stateRoot, 'failure-bridge')
@@ -1203,12 +1213,18 @@ try {
   await call('agent_teams_send_message', { to: 'flake', content: 'status update please' })
   const deliveriesBeforeFailure = deliveries.length
   const captainMailBeforeFailure = (await readMailbox(stateRoot, 'failure-bridge', 'captain')).length
+  const captainSteersBeforeFailure = captain.steers.length
 
   // The turn dies mid-stream with a transport-class failure and no idle edge.
   const failureAction = await emitRequestError(flake, {
     code: 'STREAM_CLOSED',
     message: 'SSE stream ended without [DONE]',
   })
+  check('request failure alone leaves the attempt open for Harness recovery',
+    failureAction === undefined
+      && (await readTeam(stateRoot, 'failure-bridge')).tasks.find(task => task.id === flakeTask.task_id)?.status === 'in_progress'
+      && captain.steers.length === captainSteersBeforeFailure)
+  emitTurnError(flake, { code: 'STREAM_CLOSED', message: 'SSE stream ended without [DONE]' })
   // Degraded non-atomic overwrites can hand a reader torn JSON; retry the
   // durable reads instead of letting environmental I/O noise fail the checks.
   const readTeamStable = async (teamId) => {
@@ -1223,6 +1239,12 @@ try {
   }
   const bridgeState = () => readTeamStable('failure-bridge')
   const bridgeTask = async () => (await bridgeState())?.tasks.find(candidate => candidate.id === flakeTask.task_id)
+  for (let waited = 0; waited < 2000; waited += 20) {
+    if ((await bridgeTask())?.status === 'failed' && captain.steers.length > captainSteersBeforeFailure
+      && deliveries.length > deliveriesBeforeFailure
+      && (await readUnreadMailbox(stateRoot, 'failure-bridge', 'flake')).length === 0) break
+    await new Promise(resolve => setTimeout(resolve, 20))
+  }
   const stalledFlake = (await bridgeState())?.members.find(member => member.name === 'flake')
   const captainMail = await readMailboxStable('failure-bridge', 'captain')
   check('turn failure fails the open attempt, releases the member, and owns no retry',
@@ -1235,28 +1257,12 @@ try {
       && captainMail.at(-1)?.from === 'flake'
       && captainMail.at(-1)?.to === 'captain'
       && captainMail.at(-1)?.content.includes('STREAM_CLOSED') === true
-      && captainMail.at(-1)?.content.includes(flakeTask.task_id))
-  check('turn failure dispatches nothing and leaves the question queued',
-    deliveries.length === deliveriesBeforeFailure
-      && (await readUnreadMailbox(stateRoot, 'failure-bridge', 'flake')).length === 1)
-
-  // Once the harness settles the dead turn (idle edge or handle disposal),
-  // the released member's gate reopens and the queued question flushes.
-  publishStatus(flake, 'idle')
-  let flushed = false
-  for (let waited = 0; waited < 2000; waited += 20) {
-    // Repeat the status kick: one scheduler pass can be lost to the same
-    // degraded-write noise, and mailbox flush is idempotent.
-    await call('agent_teams_status', {}).catch(() => {})
-    const unread = await readUnreadMailbox(stateRoot, 'failure-bridge', 'flake').catch(() => null)
-    if (unread !== null && deliveries.length > deliveriesBeforeFailure && unread.length === 0) {
-      flushed = true
-      break
-    }
-    await new Promise(resolve => setTimeout(resolve, 20))
-  }
-  check('settled member flushes the queued captain question with the attempt still failed',
-    flushed && (await bridgeTask())?.status === 'failed')
+      && captainMail.at(-1)?.content.includes(flakeTask.task_id)
+      && captainSteersBeforeFailure + 1 === captain.steers.length)
+  check('settled member flushes the question without idle events or manual scheduler kicks',
+    deliveries.length === deliveriesBeforeFailure + 1
+      && (await readUnreadMailbox(stateRoot, 'failure-bridge', 'flake')).length === 0
+      && (await bridgeTask())?.status === 'failed')
   await call('agent_teams_delete', {})
 } finally {
   await rm(workspace, { recursive: true, force: true })

--- a/scripts/lifecycle-verify.mjs
+++ b/scripts/lifecycle-verify.mjs
@@ -13,7 +13,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { haltTeamWork, registerAgentTeamsTools } from '../lib/tools.js'
 import { buildActivationDirective, invokedAgentTeamsGoal, invokedAgentTeamsInvocation, installAgentTeamsGestureBoundary, profileCommandName, registerAgentTeamsCommand } from '../lib/command.js'
-import { readArchivedTeam, readTeam, readUnreadMailbox } from '../lib/state.js'
+import { readArchivedTeam, readMailbox, readTeam, readUnreadMailbox } from '../lib/state.js'
 import { collectArchivedTeamsActivity } from '../lib/snapshot.js'
 
 const workspace = await mkdtemp(join(tmpdir(), 'dsh-agent-teams-lifecycle-'))
@@ -22,6 +22,8 @@ const liveAgents = new Map()
 const children = []
 const deliveries = []
 const listeners = new Map()
+const childListeners = new Map()
+const continuableSetups = []
 const failNextDelivery = new Set()
 const failures = []
 let childSeq = 0
@@ -78,6 +80,43 @@ function publishStatus(subject, status) {
   for (const listener of listeners.get('agent/status') ?? []) listener({ agent: subject, status })
 }
 
+/**
+ * Compose one child's scoped context like the harness does, so the plugin's
+ * continuable setup can install its per-child listeners (model selection and
+ * the `agent/request-error` bridge) against a dispatchable registry.
+ */
+function childContext(child) {
+  const registry = new Map()
+  childListeners.set(child.id, registry)
+  return {
+    agent: child,
+    on(name, listener) {
+      const current = registry.get(name) ?? []
+      current.push(listener)
+      registry.set(name, current)
+      return () => registry.set(name, (registry.get(name) ?? []).filter(candidate => candidate !== listener))
+    },
+  }
+}
+
+/** Dispatch one failed model request to a child's request-error listeners. */
+async function emitRequestError(child, failure) {
+  const handlers = childListeners.get(child.id)?.get('agent/request-error') ?? []
+  let action
+  for (const handler of handlers) {
+    action = await handler({
+      agent: child,
+      turn: 1,
+      step: 0,
+      provider: 'fake',
+      failure,
+      retryPolicy: undefined,
+      signal: new AbortController().signal,
+    })
+  }
+  return action
+}
+
 const captain = makeAgent('captain-session')
 liveAgents.set(captain.id, captain)
 let advertisedModels = []
@@ -112,7 +151,8 @@ const ctx = {
     },
   },
   subagents: {
-    registerContinuableSetup() {
+    registerContinuableSetup(setup) {
+      continuableSetups.push(setup)
       return () => {}
     },
     getProvider(name) {
@@ -128,6 +168,20 @@ const ctx = {
       child.status = 'running'
       liveAgents.set(id, child)
       children.push({ id, label: spec.label, mode: 'continuable' })
+      if (typeof spec.label === 'string' && spec.label.startsWith('agent-teams:')) {
+        child.session.events = [{
+          type: 'subagent/descriptor',
+          data: {
+            version: 3,
+            mode: 'continuable',
+            provider: 'spawn',
+            label: spec.label,
+            agentProvider: spec.request?.agentOptions?.provider ?? 'fake',
+            agentModel: spec.request?.agentOptions?.model ?? 'fake-model',
+          },
+        }]
+      }
+      for (const setup of continuableSetups) setup(childContext(child))
       return { childId: id, messageId: `welcome-${childSeq}` }
     },
     async listChildren(parentId) {
@@ -1000,8 +1054,21 @@ try {
   // must return to the ordinary member scheduler instead of staying white and
   // ownerless forever in the activity panel.
   publishStatus(captain, 'idle')
-  await new Promise(resolve => setTimeout(resolve, 20))
-  const afterCaptainIdle = await state()
+  // The requeue lands only after team.json's atomic write, which on Windows
+  // can stall on transient rename EPERM retries (issue #108), so poll for
+  // settlement instead of guessing a fixed wait.
+  let afterCaptainIdle = await state()
+  for (let waited = 0; waited < 2000; waited += 20) {
+    // A torn read during a degraded non-atomic overwrite must not kill the
+    // run; treat it as "not settled yet" and keep polling.
+    const settled = ((afterCaptainIdle?.tasks.filter(candidate => (
+      candidate.id === t8.task_id || candidate.id === t9.task_id
+    )) ?? []).every(candidate => candidate.assignee !== 'captain'
+      && (candidate.status === 'claimed' || candidate.status === 'in_progress')))
+    if (settled) break
+    await new Promise(resolve => setTimeout(resolve, 20))
+    afterCaptainIdle = await state().catch(() => undefined)
+  }
   const recoveredParallel = afterCaptainIdle?.tasks.filter(candidate => (
     candidate.id === t8.task_id || candidate.id === t9.task_id
   )) ?? []
@@ -1109,6 +1176,88 @@ try {
   check('same-name team can be recreated and archived again',
     await readTeam(stateRoot, teamId) === undefined
       && replacementArchive?.description === 'second generation')
+
+  // ── member turn failure bridging (issue #94) ─────────────────────────
+  // A member turn dies mid-stream with a transport-class failure and the
+  // harness emits no idle edge: the continuable handle survives and the
+  // durable record keeps the member "working". The plugin must bridge the
+  // failure at the request-error boundary (fail the open attempt, release
+  // the member, notify the captain); before the fix the request-error hook
+  // was only installed when a fallback route existed, so no-fallback teams
+  // stalled silently with a parked in_progress task.
+  await call('agent_teams_create', { name: 'Failure Bridge', description: 'turn failures must surface' })
+  await call('agent_teams_add_member', { name: 'flake', role: 'streaming worker' })
+  const flakeTeam = await readTeam(stateRoot, 'failure-bridge')
+  const flake = liveAgents.get(flakeTeam?.members.find(member => member.name === 'flake')?.id)
+  publishStatus(flake, 'idle')
+  const flakeTask = await call('agent_teams_create_task', { subject: 'streaming work', assignee: 'flake' })
+  const flakeClaim = await call('agent_teams_claim_task', { task_id: flakeTask.task_id }, flake)
+  await call('agent_teams_update_task', {
+    task_id: flakeTask.task_id, status: 'in_progress', attempt_id: flakeClaim.attempt_id,
+  }, flake)
+
+  // The captain asks the working member a question while its turn is wedged;
+  // live delivery is unavailable, so the message stays a durable fallback
+  // that only the scheduler mailbox flush can hand over.
+  failNextDelivery.add(flake.id)
+  await call('agent_teams_send_message', { to: 'flake', content: 'status update please' })
+  const deliveriesBeforeFailure = deliveries.length
+  const captainMailBeforeFailure = (await readMailbox(stateRoot, 'failure-bridge', 'captain')).length
+
+  // The turn dies mid-stream with a transport-class failure and no idle edge.
+  const failureAction = await emitRequestError(flake, {
+    code: 'STREAM_CLOSED',
+    message: 'SSE stream ended without [DONE]',
+  })
+  // Degraded non-atomic overwrites can hand a reader torn JSON; retry the
+  // durable reads instead of letting environmental I/O noise fail the checks.
+  const readTeamStable = async (teamId) => {
+    for (let attempt = 0; ; attempt += 1) {
+      try { return await readTeam(stateRoot, teamId) } catch (error) { if (attempt >= 5) throw error }
+    }
+  }
+  const readMailboxStable = async (teamId, agentKey) => {
+    for (let attempt = 0; ; attempt += 1) {
+      try { return await readMailbox(stateRoot, teamId, agentKey) } catch (error) { if (attempt >= 5) throw error }
+    }
+  }
+  const bridgeState = () => readTeamStable('failure-bridge')
+  const bridgeTask = async () => (await bridgeState())?.tasks.find(candidate => candidate.id === flakeTask.task_id)
+  const stalledFlake = (await bridgeState())?.members.find(member => member.name === 'flake')
+  const captainMail = await readMailboxStable('failure-bridge', 'captain')
+  check('turn failure fails the open attempt, releases the member, and owns no retry',
+    failureAction === undefined
+      && (await bridgeTask())?.status === 'failed'
+      && (await bridgeTask())?.output?.includes('STREAM_CLOSED') === true
+      && stalledFlake?.status === 'idle')
+  check('turn failure notifies the captain mailbox with the error code',
+    captainMail.length === captainMailBeforeFailure + 1
+      && captainMail.at(-1)?.from === 'flake'
+      && captainMail.at(-1)?.to === 'captain'
+      && captainMail.at(-1)?.content.includes('STREAM_CLOSED') === true
+      && captainMail.at(-1)?.content.includes(flakeTask.task_id))
+  check('turn failure dispatches nothing and leaves the question queued',
+    deliveries.length === deliveriesBeforeFailure
+      && (await readUnreadMailbox(stateRoot, 'failure-bridge', 'flake')).length === 1)
+
+  // Once the harness settles the dead turn (idle edge or handle disposal),
+  // the released member's gate reopens and the queued question flushes.
+  publishStatus(flake, 'idle')
+  let flushed = false
+  for (let waited = 0; waited < 2000; waited += 20) {
+    // Repeat the status kick: one scheduler pass can be lost to the same
+    // degraded-write noise, and mailbox flush is idempotent.
+    await call('agent_teams_status', {}).catch(() => {})
+    const unread = await readUnreadMailbox(stateRoot, 'failure-bridge', 'flake').catch(() => null)
+    if (unread !== null && deliveries.length > deliveriesBeforeFailure && unread.length === 0) {
+      flushed = true
+      break
+    }
+    await new Promise(resolve => setTimeout(resolve, 20))
+  }
+  check('settled member flushes the queued captain question with the attempt still failed',
+    flushed && (await bridgeTask())?.status === 'failed')
+  await call('agent_teams_delete', {})
 } finally {
   await rm(workspace, { recursive: true, force: true })
 }

--- a/scripts/member-failure-tdd.mjs
+++ b/scripts/member-failure-tdd.mjs
@@ -1,0 +1,224 @@
+/** Terminal member failures, composed with Harness's actual retry plugin. */
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { setTimeout as delay } from 'node:timers/promises'
+import { LlmError } from '@deepseek-ai/dsh-llm'
+import { apply as installRetry } from '@deepseek-ai/dsh-llm-retry'
+import { installMemberSelectionRuntime } from '../lib/members.js'
+import { installTeamScheduler } from '../lib/scheduler.js'
+import { appendMailbox, createMessage, createTeamDir, readTeam, readMailbox, readUnreadMailbox, withTeamLock, writeTeam } from '../lib/state.js'
+
+async function eventually(predicate) {
+  for (let i = 0; i < 100; i++) {
+    if (await predicate()) return
+    await delay(10)
+  }
+  assert.fail('terminal failure did not settle')
+}
+
+async function fixture(t, { captainStatus = 'idle', fallback, captainOffline = false, rejectDelivery = false } = {}) {
+  const workspace = await mkdtemp(join(tmpdir(), 'dsh-member-failure-'))
+  const pendingFailures = []
+  let settleOnCleanup = () => {}
+  t.after(async () => {
+    settleOnCleanup()
+    await Promise.all(pendingFailures)
+    await rm(workspace, { recursive: true, force: true })
+  })
+  const stateRoot = join(workspace, '.agent-teams')
+  const listeners = new Map()
+  const steers = []
+  const deliveries = []
+  const warnings = []
+  const sessionEvents = []
+  const captain = {
+    id: 'captain', status: captainStatus,
+    session: { append() {} },
+    steer(message) {
+      if (rejectDelivery) throw new Error('captain cannot receive')
+      steers.push(message)
+    },
+  }
+  let resolveIdle
+  const idle = new Promise(resolve => { resolveIdle = resolve })
+  const child = {
+    id: 'worker-session', status: 'running',
+    whenIdle: () => child.status === 'idle' ? Promise.resolve() : idle,
+    session: {
+      header: { cwd: workspace, parentSession: captain.id, seedLength: 0 },
+      events: [{ type: 'subagent/descriptor', data: {
+        version: 3, mode: 'continuable', provider: 'spawn', label: 'agent-teams:team:worker',
+        agentProvider: 'fake', agentModel: 'primary',
+      } }],
+      append(type, data) { sessionEvents.push({ type, data }) },
+    },
+  }
+  await createTeamDir(stateRoot, {
+    id: 'team', name: 'Team', captainSessionId: captain.id, createdAt: 1, taskSeq: 1,
+    members: [{ id: child.id, name: 'worker', status: 'working', joinedAt: 1, provider: 'fake', model: 'primary' }],
+    tasks: [{ id: 't1', subject: 'work', assignee: 'worker', status: 'in_progress', dependencies: [], attempt: 1, attemptId: 'a1', createdAt: 1, updatedAt: 1 }],
+  })
+  let setup
+  const ctx = {
+    logger: { debug() {}, warn(message) { warnings.push(message) } },
+    agents: { get(id) { return id === child.id ? child : id === captain.id && !captainOffline ? captain : undefined } },
+    on() { return () => {} },
+    subagents: {
+      registerContinuableSetup(fn) { setup = fn },
+      async followup(_captain, id, content) { deliveries.push({ id, content }); return 'accepted' },
+    },
+  }
+  const scheduler = installTeamScheduler(ctx, { stateDir: '.agent-teams' })
+  const runtime = installMemberSelectionRuntime(ctx, '.agent-teams', (workspace, teamId, memberName) => (
+    scheduler.kickMember(workspace, teamId, memberName)
+  ))
+  const dispose = await runtime.withPending(captain.id, 'agent-teams:team:worker', {
+    provider: 'fake', model: 'primary', ...fallback ? { fallback } : {},
+  }, () => setup({
+    agent: child,
+    on(name, listener) { listeners.set(name, listener); return () => listeners.delete(name) },
+  }))
+  t.after(dispose)
+  let retryHandler
+  let projection
+  let retryState = {}
+  const retryDisposers = []
+  installRetry({
+    logger: ctx.logger,
+    sessionProjections: { register(value) { projection = value }, stateOf() { return retryState } },
+    on(_name, listener) { retryHandler = listener; return () => {} },
+    effect(setup) { retryDisposers.push(setup()) },
+  })
+  t.after(async () => { for (const dispose of retryDisposers) await dispose() })
+  child.session.append = (type, data) => {
+    sessionEvents.push({ type, data })
+    retryState = projection.apply(retryState, { type, data })
+  }
+  const failure = { code: 'STREAM_CLOSED', message: 'SSE stream ended without [DONE]' }
+  const payload = (policy, code = failure.code, signal = new AbortController().signal) => ({
+    agent: child, turn: 1, step: 0, provider: 'fake', failure: { ...failure, code }, retryPolicy: policy, signal,
+  })
+  const memberError = (value, next = async () => undefined) => listeners.get('agent/request-error')?.(value, next) ?? next()
+  const settleSilently = () => {
+    // The real driver settles after emitting agent/error. Deliberately omit
+    // agent/status so recovery cannot depend on that edge reaching the plugin.
+    child.status = 'idle'
+    resolveIdle()
+  }
+  settleOnCleanup = settleSilently
+  return {
+    stateRoot, steers, deliveries, warnings, listeners, child, sessionEvents, memberError, payload, settleSilently,
+    state: () => readTeam(stateRoot, 'team'),
+    mailbox: () => readMailbox(stateRoot, 'team', 'captain'),
+    unread: () => readUnreadMailbox(stateRoot, 'team', 'captain'),
+    retry: (policy, code) => { const value = payload(policy, code); return retryHandler(value, () => memberError(value)) },
+    terminal({ settle = true, turn = 1 } = {}) {
+      pendingFailures.push(listeners.get('agent/error')?.({ agent: child, turn, step: 0, error: new LlmError(failure.message, failure.code) }))
+      if (settle) settleSilently()
+    },
+  }
+}
+
+const normal = { mode: 'normal', maxRetries: 1, retryableCodes: ['STREAM_CLOSED'], initialDelayMs: 0, maxDelayMs: 0, jitterRatio: 0 }
+const always = { mode: 'always', initialDelayMs: 0, maxDelayMs: 0, jitterRatio: 0 }
+
+await test('always retry keeps the owned task open and sends no false failure report', async t => {
+  const h = await fixture(t)
+  assert.deepEqual(await h.retry(always), { kind: 'retry' })
+  assert.equal((await h.state()).tasks[0].status, 'in_progress')
+  assert.equal((await h.mailbox()).length, 0)
+})
+
+await test('request handler delegates recovery and leaves exhausted requests open until final error', async t => {
+  const h = await fixture(t)
+  let delegated = 0
+  assert.deepEqual(await h.memberError(h.payload(undefined), async () => { delegated++; return { kind: 'retry' } }), { kind: 'retry' })
+  assert.equal(delegated, 1)
+  assert.deepEqual(await h.retry(normal), { kind: 'retry' })
+  assert.equal(await h.retry(normal), undefined)
+  assert.equal((await h.state()).tasks[0].status, 'in_progress')
+})
+
+await test('fallback recovers once and exhausted fallback still delegates without failing the task', async t => {
+  const h = await fixture(t, { fallback: { provider: 'backup', model: 'backup-model' } })
+  assert.deepEqual(await h.memberError(h.payload(undefined, 'AUTH')), { kind: 'retry' })
+  assert.deepEqual(await h.memberError(h.payload(undefined, 'RATE_LIMIT'), async () => ({ kind: 'retry' })), { kind: 'retry' })
+  assert.equal((await h.state()).tasks[0].status, 'in_progress')
+})
+
+await test('aborted request does not fail a task or consume its fallback route', async t => {
+  const h = await fixture(t, { fallback: { provider: 'backup', model: 'backup-model' } })
+  const abort = new AbortController()
+  abort.abort()
+  assert.equal(await h.memberError(h.payload(undefined, 'AUTH', abort.signal)), undefined)
+  assert.deepEqual(await h.memberError(h.payload(undefined, 'AUTH')), { kind: 'retry' })
+  assert.equal((await h.state()).tasks[0].status, 'in_progress')
+})
+
+for (const captainStatus of ['idle', 'running']) {
+  await test(`final failure notifies ${captainStatus} captain once and flushes without an idle event`, async t => {
+    const h = await fixture(t, { captainStatus })
+    await appendMailbox(h.stateRoot, 'team', 'worker', createMessage('captain', 'worker', 'status please'))
+    h.terminal()
+    h.terminal()
+    await eventually(async () => (await h.state()).tasks[0].status === 'failed' && h.steers.length === 1 && h.deliveries.length === 1)
+    assert.equal((await h.state()).tasks[0].attemptId, 'a1')
+    assert.match((await h.state()).tasks[0].output, /STREAM_CLOSED/)
+    assert.equal((await h.state()).members[0].status, 'idle')
+    assert.match(JSON.stringify(h.steers[0]), /t1/)
+    assert.match(JSON.stringify(h.steers[0]), /STREAM_CLOSED/)
+    await eventually(async () => (await h.unread()).length === 0)
+    assert.equal((await h.mailbox()).length, 1)
+    assert.equal((await readUnreadMailbox(h.stateRoot, 'team', 'worker')).length, 0)
+    assert.equal(h.warnings.length, 0)
+  })
+}
+
+await test('report a final error immediately but do not dispatch while the driver is still running', async t => {
+  const h = await fixture(t)
+  await appendMailbox(h.stateRoot, 'team', 'worker', createMessage('captain', 'worker', 'status please'))
+  h.terminal({ settle: false })
+  await eventually(async () => (await h.state()).tasks[0].status === 'failed' && h.steers.length === 1)
+  assert.equal(h.child.status, 'running')
+  assert.equal((await h.state()).members[0].status, 'working')
+  assert.equal(h.deliveries.length, 0)
+  h.settleSilently()
+  await eventually(() => h.deliveries.length === 1)
+  assert.equal((await h.state()).members[0].status, 'idle')
+})
+
+for (const options of [{ captainOffline: true }, { rejectDelivery: true }]) {
+  await test(`unavailable captain keeps failure notification readable: ${JSON.stringify(options)}`, async t => {
+    const h = await fixture(t, options)
+    h.terminal()
+    await eventually(async () => (await h.unread()).length === 1)
+    assert.equal((await h.state()).tasks[0].status, 'failed')
+    assert.equal(h.steers.length, 0)
+  })
+}
+
+await test('a queued error cannot fail a newer attempt created before it gets the team lock', async t => {
+  const h = await fixture(t)
+  let release
+  let locked
+  const ready = new Promise(resolve => { locked = resolve })
+  const lock = withTeamLock(`team:${h.stateRoot}:team`, async () => {
+    locked()
+    await new Promise(resolve => { release = resolve })
+    const team = await h.state()
+    team.tasks[0].attempt = 2
+    team.tasks[0].attemptId = 'a2'
+    await writeTeam(h.stateRoot, team)
+  })
+  await ready
+  h.terminal()
+  release()
+  await lock
+  await withTeamLock(`team:${h.stateRoot}:team`, async () => {})
+  assert.equal((await h.state()).tasks[0].status, 'in_progress')
+  assert.equal((await h.state()).tasks[0].attemptId, 'a2')
+  assert.equal((await h.mailbox()).length, 0)
+})

--- a/scripts/verify.mjs
+++ b/scripts/verify.mjs
@@ -1514,7 +1514,7 @@ try {
           `$f = '${transientJson.replaceAll("'", "''")}';
            $s = [System.IO.File]::Open($f, [IO.FileMode]::Open, [IO.FileAccess]::ReadWrite, [IO.FileShare]::ReadWrite);
            [Console]::Out.WriteLine('HELD_T'); [Console]::Out.Flush();
-           Start-Sleep -Milliseconds 140; $s.Dispose()`],
+           Start-Sleep -Milliseconds 80; $s.Dispose()`],
         { stdio: ['ignore', 'pipe', 'inherit'] },
       )
       const flashed = await new Promise((resolve, reject) => {
@@ -1537,8 +1537,10 @@ try {
         flasher.on('exit', onExit)
       })
       try {
-        // The flasher releases after ~140 ms; archiveTeamDir retries the
-        // rename across that window, so archiving must still succeed.
+        // The flasher releases after ~80 ms (plus process exit jitter): the
+        // lock must outlive the first rename attempt but land comfortably
+        // inside the 3x50 ms retry budget, including the PowerShell dispose
+        // jitter that previously pushed a 140 ms hold past it (issue #108).
         await archiveTeamDir(atomicStateRoot, transientTeam.id)
         const archived = await readFile(join(atomicStateRoot, 'archive', transientTeam.id, 'team.json'), 'utf8')
         check(

--- a/src/members.ts
+++ b/src/members.ts
@@ -17,9 +17,10 @@ import { installModelSelection, type Agent, type ModelSelection } from '@deepsee
 // Declaration merge only: makes ctx.subagents visible.
 import { foldSubagentDescriptor, SubagentError } from '@deepseek-ai/dsh-subagent'
 import { ReasoningEffortId } from '@deepseek-ai/dsh-llm'
-import type { SessionId } from '@deepseek-ai/dsh-session'
+import type { Session, SessionId } from '@deepseek-ai/dsh-session'
 import { join } from 'node:path'
-import { readRetiredMemberIds, readTeamSync, readTeam, withTeamLock, writeTeam } from './state.ts'
+import { appendMailbox, CAPTAIN_KEY, createMessage, readRetiredMemberIds, readTeamSync, readTeam, withTeamLock, writeTeam } from './state.ts'
+import { appendTeamEvent, captainSessionOf } from './events.ts'
 import { TERMINAL_TASK_STATUSES, type TeamMember, type TeamState } from './types.ts'
 
 /** Persona snapshot of a profile protocol; the full text lives on team.json. */
@@ -141,6 +142,73 @@ export function selectFallbackRoute(
     return { retry: false, switched: alreadySwitched, selection: current }
   }
   return { retry: true, switched: true, selection: fallback }
+}
+
+/**
+ * Bridge one unrecoverable member turn failure into durable team state
+ * (issue #94).
+ *
+ * A member turn can die mid-request — for example `STREAM_CLOSED` when an
+ * SSE stream ends without `[DONE]` — without the harness ever reporting an
+ * idle edge or disposing the handle. The member then stays `working` and its
+ * open attempt stays `claimed`/`in_progress` forever: the scheduler's
+ * availability gate never reopens, mailbox flushes never reach the member,
+ * and the captain is never told. The `agent/request-error` hook fires before
+ * the failed turn closes, so it is the one reliable observation point.
+ *
+ * Semantics: the owned open attempt is marked `failed` rather than returned
+ * to `pending`. `claimed`/`in_progress` → `failed` are existing legal
+ * transitions, the terminal record keeps the failed generation inspectable,
+ * and requeueing instead would re-dispatch the same work on the next kick and
+ * recreate an unbounded failure/dispatch loop for transport-class errors (the
+ * issue #66 feedback shape) because automatic retry budgeting does not exist.
+ * The captain mailbox notification is the recovery path.
+ *
+ * The write is skipped when the member owns no open attempt and was not
+ * recorded `working`: that failure self-heals on the eventual idle edge and
+ * would only spam the captain's mailbox.
+ *
+ * All mutations run under the team lock through the ordinary durable path.
+ * Errors propagate to the caller, which logs and never rethrows into the
+ * request-error waterfall.
+ */
+export async function failMemberOpenAttempt(
+  ctx: Context,
+  stateRoot: string,
+  teamId: string,
+  memberName: string,
+  failure: { readonly code: string; readonly message: string },
+  fallbackSession: Session,
+): Promise<void> {
+  const summary = `${failure.message} (code ${failure.code})`
+  await withTeamLock(`team:${stateRoot}:${teamId}`, async () => {
+    const team = await readTeam(stateRoot, teamId)
+    if (team === undefined || team.halted === true) return
+    const member = team.members.find(candidate => candidate.name === memberName && candidate.status !== 'removed')
+    if (member === undefined) return
+    const task = team.tasks.find(candidate => candidate.assignee === memberName
+      && (candidate.status === 'claimed' || candidate.status === 'in_progress'))
+    if (task === undefined && member.status !== 'working') return
+    if (task !== undefined) {
+      task.status = 'failed'
+      task.output = summary
+      task.updatedAt = Date.now()
+    }
+    member.status = 'idle'
+    const message = createMessage(memberName, CAPTAIN_KEY, task === undefined
+      ? `Member "${memberName}" hit an unrecoverable turn failure: ${summary}. No open attempt was owned; the member is available again.`
+      : `Member "${memberName}" hit an unrecoverable turn failure: ${summary}. Task ${task.id} ("${task.subject}") was marked failed; reassign it or retry when ready.`)
+    await appendMailbox(stateRoot, team.id, CAPTAIN_KEY, message)
+    appendTeamEvent(ctx, captainSessionOf(ctx, team.captainSessionId, fallbackSession), 'agent-teams/message-sent', {
+      teamId: team.id,
+      messageId: message.id,
+      from: memberName,
+      to: CAPTAIN_KEY,
+      content: message.content,
+      ts: message.ts,
+    })
+    await writeTeam(stateRoot, team)
+  })
 }
 
 async function updateFallbackState(
@@ -311,26 +379,57 @@ export function installMemberSelectionRuntime(ctx: Context, stateDir: string): M
     const selectionRef = { current: modelSelection(selection), assembled: undefined as ModelSelection | undefined }
     const disposeSelection = installModelSelection(childCtx, selectionRef)
     const fallback = selection.fallback
-    if (fallback === undefined) return disposeSelection
     let switched = false
+    // Installed unconditionally: with no fallback configured this handler is
+    // still the only place that observes a member turn dying mid-request, so
+    // it must bridge the failure into team state (issue #94) even though it
+    // has no route to switch to.
     const disposeFallback = childCtx.on('agent/request-error', async (payload) => {
       if (payload.agent.id !== child.id) return undefined
       const transition = selectFallbackRoute(selectionRef.current ?? { provider: selection.provider, model: selection.model }, fallback, payload.failure.code, switched)
-      if (!transition.retry) return undefined
-      switched = transition.switched
-      selectionRef.current = transition.selection
+      // selectFallbackRoute only retries when a fallback route exists; the
+      // explicit guard narrows that fact for the compiler.
+      if (fallback !== undefined && transition.retry) {
+        switched = transition.switched
+        selectionRef.current = transition.selection
+        const workspace = child.session.header.cwd ?? process.cwd()
+        const identity = descriptor.label.slice(MEMBER_LABEL_PREFIX.length)
+        const separator = identity.indexOf(':')
+        if (separator > 0) {
+          const teamId = identity.slice(0, separator)
+          const memberName = identity.slice(separator + 1)
+          void updateFallbackState(join(workspace, stateDir), teamId, memberName, fallback, ctx).catch((error: unknown) => {
+            ctx.logger.warn(`agent-teams: failed to persist fallback route: ${String(error)}`)
+          })
+        }
+        ctx.logger.warn(`agent-teams: member ${child.id} switching to fallback ${fallback.provider}/${fallback.model} after ${payload.failure.code}`)
+        return { kind: 'retry' as const }
+      }
+      // Unrecoverable: no fallback configured, the code is not one a route
+      // switch can fix (transport-class failures like STREAM_CLOSED), or the
+      // fallback route already failed. Leave the failure terminal (no retry —
+      // retrying without a route change would loop) and bridge it into team
+      // state so the scheduler gate reopens and the captain is notified.
       const workspace = child.session.header.cwd ?? process.cwd()
       const identity = descriptor.label.slice(MEMBER_LABEL_PREFIX.length)
       const separator = identity.indexOf(':')
       if (separator > 0) {
         const teamId = identity.slice(0, separator)
         const memberName = identity.slice(separator + 1)
-        void updateFallbackState(join(workspace, stateDir), teamId, memberName, fallback, ctx).catch((error: unknown) => {
-          ctx.logger.warn(`agent-teams: failed to persist fallback route: ${String(error)}`)
-        })
+        try {
+          await failMemberOpenAttempt(
+            ctx,
+            join(workspace, stateDir),
+            teamId,
+            memberName,
+            { code: payload.failure.code, message: payload.failure.message },
+            child.session,
+          )
+        } catch (error: unknown) {
+          ctx.logger.warn(`agent-teams: failed to record member turn failure: ${String(error)}`)
+        }
       }
-      ctx.logger.warn(`agent-teams: member ${child.id} switching to fallback ${fallback.provider}/${fallback.model} after ${payload.failure.code}`)
-      return { kind: 'retry' as const }
+      return undefined
     })
     return () => {
       disposeFallback()

--- a/src/members.ts
+++ b/src/members.ts
@@ -16,12 +16,12 @@ import type { Context } from '@deepseek-ai/cordis'
 import { installModelSelection, type Agent, type ModelSelection } from '@deepseek-ai/dsh-agent'
 // Declaration merge only: makes ctx.subagents visible.
 import { foldSubagentDescriptor, SubagentError } from '@deepseek-ai/dsh-subagent'
-import { ReasoningEffortId } from '@deepseek-ai/dsh-llm'
+import { createUserMessage, LlmError, ReasoningEffortId } from '@deepseek-ai/dsh-llm'
 import type { Session, SessionId } from '@deepseek-ai/dsh-session'
 import { join } from 'node:path'
-import { appendMailbox, CAPTAIN_KEY, createMessage, readRetiredMemberIds, readTeamSync, readTeam, withTeamLock, writeTeam } from './state.ts'
+import { acknowledgeMailbox, appendMailbox, CAPTAIN_KEY, createMessage, readRetiredMemberIds, readTeamSync, readTeam, releaseMailboxDelivery, withTeamLock, writeTeam } from './state.ts'
 import { appendTeamEvent, captainSessionOf } from './events.ts'
-import { TERMINAL_TASK_STATUSES, type TeamMember, type TeamState } from './types.ts'
+import { TERMINAL_TASK_STATUSES, type TeamMember, type TeamState, type TeamTask } from './types.ts'
 
 /** Persona snapshot of a profile protocol; the full text lives on team.json. */
 export const PERSONA_PROTOCOL_MAX_CHARS = 400
@@ -144,34 +144,26 @@ export function selectFallbackRoute(
   return { retry: true, switched: true, selection: fallback }
 }
 
-/**
- * Bridge one unrecoverable member turn failure into durable team state
- * (issue #94).
- *
- * A member turn can die mid-request — for example `STREAM_CLOSED` when an
- * SSE stream ends without `[DONE]` — without the harness ever reporting an
- * idle edge or disposing the handle. The member then stays `working` and its
- * open attempt stays `claimed`/`in_progress` forever: the scheduler's
- * availability gate never reopens, mailbox flushes never reach the member,
- * and the captain is never told. The `agent/request-error` hook fires before
- * the failed turn closes, so it is the one reliable observation point.
- *
- * Semantics: the owned open attempt is marked `failed` rather than returned
- * to `pending`. `claimed`/`in_progress` → `failed` are existing legal
- * transitions, the terminal record keeps the failed generation inspectable,
- * and requeueing instead would re-dispatch the same work on the next kick and
- * recreate an unbounded failure/dispatch loop for transport-class errors (the
- * issue #66 feedback shape) because automatic retry budgeting does not exist.
- * The captain mailbox notification is the recovery path.
- *
- * The write is skipped when the member owns no open attempt and was not
- * recorded `working`: that failure self-heals on the eventual idle edge and
- * would only spam the captain's mailbox.
- *
- * All mutations run under the team lock through the ordinary durable path.
- * Errors propagate to the caller, which logs and never rethrows into the
- * request-error waterfall.
- */
+/** Deliver a durable member report to the live captain at its next model step. */
+export function steerCaptainReport(captain: Pick<Agent, 'steer'>, from: string, content: string): boolean {
+  try {
+    captain.steer(createUserMessage({
+      content: [{ type: 'text', text: `AgentTeams message from member ${from}:\n\n${content}` }],
+      source: { kind: 'plugin', plugin: 'dsh-agent-teams' },
+    }))
+    return true
+  } catch {
+    return false
+  }
+}
+
+interface FailedMemberAttempt {
+  readonly captainSessionId: string
+  readonly memberId: string
+  readonly task?: Pick<TeamTask, 'id' | 'attempt' | 'attemptId'>
+}
+
+/** Record a final turn failure, never an intermediate request retry. */
 export async function failMemberOpenAttempt(
   ctx: Context,
   stateRoot: string,
@@ -179,26 +171,42 @@ export async function failMemberOpenAttempt(
   memberName: string,
   failure: { readonly code: string; readonly message: string },
   fallbackSession: Session,
-): Promise<void> {
+  observed: FailedMemberAttempt,
+): Promise<boolean> {
   const summary = `${failure.message} (code ${failure.code})`
-  await withTeamLock(`team:${stateRoot}:${teamId}`, async () => {
+  const lockKey = `team:${stateRoot}:${teamId}`
+  const prepared = await withTeamLock(lockKey, async () => {
     const team = await readTeam(stateRoot, teamId)
-    if (team === undefined || team.halted === true) return
-    const member = team.members.find(candidate => candidate.name === memberName && candidate.status !== 'removed')
+    if (team === undefined || team.halted === true || team.captainSessionId !== observed.captainSessionId) return
+    const member = team.members.find(candidate => candidate.name === memberName
+      && candidate.id === observed.memberId && candidate.status !== 'removed')
     if (member === undefined) return
     const task = team.tasks.find(candidate => candidate.assignee === memberName
       && (candidate.status === 'claimed' || candidate.status === 'in_progress'))
+    // A reassign, completion, or recreated member may win the lock while the
+    // final error is queued. Only the capability observed at that event may fail.
+    if (task?.id !== observed.task?.id || task?.attemptId !== observed.task?.attemptId
+      || task?.attempt !== observed.task?.attempt) return
     if (task === undefined && member.status !== 'working') return
     if (task !== undefined) {
       task.status = 'failed'
       task.output = summary
       task.updatedAt = Date.now()
     }
-    member.status = 'idle'
-    const message = createMessage(memberName, CAPTAIN_KEY, task === undefined
-      ? `Member "${memberName}" hit an unrecoverable turn failure: ${summary}. No open attempt was owned; the member is available again.`
-      : `Member "${memberName}" hit an unrecoverable turn failure: ${summary}. Task ${task.id} ("${task.subject}") was marked failed; reassign it or retry when ready.`)
+    if (ctx.agents.get(brandedSessionId(member.id))?.status !== 'running') member.status = 'idle'
+    const message = {
+      ...createMessage(memberName, CAPTAIN_KEY, task === undefined
+        ? `Member "${memberName}" hit an unrecoverable turn failure: ${summary}. No open attempt was owned.`
+        : `Member "${memberName}" hit an unrecoverable turn failure: ${summary}. Task ${task.id} ("${task.subject}") was marked failed; reassign it or retry when ready.`),
+      deliveryClaimedAt: Date.now(),
+    }
+    await writeTeam(stateRoot, team)
     await appendMailbox(stateRoot, team.id, CAPTAIN_KEY, message)
+    if (task !== undefined) {
+      appendTeamEvent(ctx, captainSessionOf(ctx, team.captainSessionId, fallbackSession), 'agent-teams/task-updated', {
+        teamId, taskId: task.id, status: task.status, assignee: memberName, output: task.output,
+      })
+    }
     appendTeamEvent(ctx, captainSessionOf(ctx, team.captainSessionId, fallbackSession), 'agent-teams/message-sent', {
       teamId: team.id,
       messageId: message.id,
@@ -207,8 +215,17 @@ export async function failMemberOpenAttempt(
       content: message.content,
       ts: message.ts,
     })
-    await writeTeam(stateRoot, team)
+    return { captainSessionId: team.captainSessionId, message }
   })
+  if (prepared === undefined) return false
+  // Use the same lease/acknowledgment contract as send_message, outside the
+  // team lock: steering can synchronously start another agent turn.
+  const captain = ctx.agents.get(brandedSessionId(prepared.captainSessionId))
+  const delivered = captain !== undefined && steerCaptainReport(captain, memberName, prepared.message.content)
+  await withTeamLock(lockKey, () => delivered
+    ? acknowledgeMailbox(stateRoot, teamId, CAPTAIN_KEY, [prepared.message.id])
+    : releaseMailboxDelivery(stateRoot, teamId, CAPTAIN_KEY, [prepared.message.id]))
+  return true
 }
 
 async function updateFallbackState(
@@ -340,7 +357,11 @@ export async function resolveMemberLlmSelection(
  * record. Legacy members without a complete saved route retain Harness's
  * descriptor provider/model behavior.
  */
-export function installMemberSelectionRuntime(ctx: Context, stateDir: string): MemberSelectionRuntime {
+export function installMemberSelectionRuntime(
+  ctx: Context,
+  stateDir: string,
+  onFailureSettled?: (workspace: string, teamId: string, memberName: string) => Promise<void>,
+): MemberSelectionRuntime {
   const pending = new Map<string, MemberLlmSelection>()
   ctx.subagents.registerContinuableSetup((childCtx) => {
     const child = childCtx.agent
@@ -353,87 +374,95 @@ export function installMemberSelectionRuntime(ctx: Context, stateDir: string): M
 
     const parentSessionId = child.session.header.parentSession
     if (parentSessionId === undefined) return () => undefined
+    const identity = descriptor.label.slice(MEMBER_LABEL_PREFIX.length)
+    const separator = identity.indexOf(':')
+    if (separator < 1 || separator === identity.length - 1) return () => undefined
+    const teamId = identity.slice(0, separator)
+    const memberName = identity.slice(separator + 1)
+    const workspace = child.session.header.cwd ?? process.cwd()
+    const stateRoot = join(workspace, stateDir)
     const key = pendingSelectionKey(parentSessionId, descriptor.label)
     let selection = pending.get(key)
     if (selection === undefined) {
-      const identity = descriptor.label.slice(MEMBER_LABEL_PREFIX.length)
-      const separator = identity.indexOf(':')
-      if (separator < 1 || separator === identity.length - 1) return () => undefined
-      const teamId = identity.slice(0, separator)
-      const memberName = identity.slice(separator + 1)
-      const workspace = child.session.header.cwd ?? process.cwd()
-      const team = readTeamSync(join(workspace, stateDir), teamId)
+      const team = readTeamSync(stateRoot, teamId)
       if (team?.captainSessionId !== parentSessionId) return () => undefined
       const durableMember = team.members.find(member => member.name === memberName)
       selection = selectionFromMember(durableMember)
-      // An old team record has no provider/reasoning snapshot. Its durable
-      // Harness descriptor still restores provider/model, so leave it alone.
-      if (selection === undefined) return () => undefined
-      if (descriptor.agentProvider !== durableMember?.provider || descriptor.agentModel !== durableMember?.model) {
+      if (selection !== undefined && (descriptor.agentProvider !== durableMember?.provider || descriptor.agentModel !== durableMember?.model)) {
         throw new Error(
           `agent-teams: saved model route for member "${memberName}" does not match its subagent descriptor`,
         )
       }
     }
 
+    let lastFailedTurn: number | undefined
+    // Harness emits agent/error only after request recovery is exhausted. In
+    // particular, llm-retry's "always" policy calls downstream request-error
+    // listeners before it retries; that waterfall cannot declare a turn dead.
+    const disposeFailure = childCtx.on('agent/error', async (payload) => {
+      if (payload.agent.id !== child.id || payload.turn === lastFailedTurn) return
+      lastFailedTurn = payload.turn
+      try {
+        // Capture the attempt synchronously at the event, before any lock wait
+        // can let a captain reassign it or replace the member/team generation.
+        const snapshot = readTeamSync(stateRoot, teamId)
+        if (snapshot?.captainSessionId !== parentSessionId) return
+        const member = snapshot.members.find(item => item.id === child.id && item.name === memberName && item.status !== 'removed')
+        if (member === undefined) return
+        const task = snapshot.tasks.find(item => item.assignee === memberName
+          && (item.status === 'claimed' || item.status === 'in_progress'))
+        const failure = payload.error instanceof LlmError ? payload.error.failure : {
+          code: 'UNKNOWN',
+          message: payload.error instanceof Error ? payload.error.message : String(payload.error),
+        }
+        const recorded = await failMemberOpenAttempt(ctx, stateRoot, teamId, memberName, failure, child.session, {
+          captainSessionId: parentSessionId, memberId: child.id, task,
+        })
+        if (!recorded) return
+        // The final-error event precedes driver quiescence. Observe the real
+        // lifecycle and kick explicitly even if its idle event was missed.
+        // Never force an active Agent's status to idle or retry the failed task.
+        await child.whenIdle()
+        await withTeamLock(`team:${stateRoot}:${teamId}`, async () => {
+          const team = await readTeam(stateRoot, teamId)
+          const current = team?.members.find(item => item.id === child.id && item.name === memberName && item.status !== 'removed')
+          if (team?.captainSessionId !== parentSessionId || current === undefined || child.status !== 'idle') return
+          if (current.status !== 'idle') {
+            current.status = 'idle'
+            await writeTeam(stateRoot, team)
+          }
+        })
+        await onFailureSettled?.(workspace, teamId, memberName)
+      } catch (error: unknown) {
+        ctx.logger.warn(`agent-teams: failed to record member turn failure: ${String(error)}`)
+      }
+    })
+    // Legacy teams still need failure reporting even without a saved route.
+    if (selection === undefined) return disposeFailure
     const selectionRef = { current: modelSelection(selection), assembled: undefined as ModelSelection | undefined }
     const disposeSelection = installModelSelection(childCtx, selectionRef)
     const fallback = selection.fallback
     let switched = false
-    // Installed unconditionally: with no fallback configured this handler is
-    // still the only place that observes a member turn dying mid-request, so
-    // it must bridge the failure into team state (issue #94) even though it
-    // has no route to switch to.
-    const disposeFallback = childCtx.on('agent/request-error', async (payload) => {
-      if (payload.agent.id !== child.id) return undefined
+    const disposeFallback = childCtx.on('agent/request-error', async (payload, next) => {
+      if (payload.agent.id !== child.id || payload.signal.aborted) return next()
       const transition = selectFallbackRoute(selectionRef.current ?? { provider: selection.provider, model: selection.model }, fallback, payload.failure.code, switched)
       // selectFallbackRoute only retries when a fallback route exists; the
       // explicit guard narrows that fact for the compiler.
       if (fallback !== undefined && transition.retry) {
         switched = transition.switched
         selectionRef.current = transition.selection
-        const workspace = child.session.header.cwd ?? process.cwd()
-        const identity = descriptor.label.slice(MEMBER_LABEL_PREFIX.length)
-        const separator = identity.indexOf(':')
-        if (separator > 0) {
-          const teamId = identity.slice(0, separator)
-          const memberName = identity.slice(separator + 1)
-          void updateFallbackState(join(workspace, stateDir), teamId, memberName, fallback, ctx).catch((error: unknown) => {
-            ctx.logger.warn(`agent-teams: failed to persist fallback route: ${String(error)}`)
-          })
-        }
+        await updateFallbackState(stateRoot, teamId, memberName, fallback, ctx).catch((error: unknown) => {
+          ctx.logger.warn(`agent-teams: failed to persist fallback route: ${String(error)}`)
+        })
         ctx.logger.warn(`agent-teams: member ${child.id} switching to fallback ${fallback.provider}/${fallback.model} after ${payload.failure.code}`)
         return { kind: 'retry' as const }
       }
-      // Unrecoverable: no fallback configured, the code is not one a route
-      // switch can fix (transport-class failures like STREAM_CLOSED), or the
-      // fallback route already failed. Leave the failure terminal (no retry —
-      // retrying without a route change would loop) and bridge it into team
-      // state so the scheduler gate reopens and the captain is notified.
-      const workspace = child.session.header.cwd ?? process.cwd()
-      const identity = descriptor.label.slice(MEMBER_LABEL_PREFIX.length)
-      const separator = identity.indexOf(':')
-      if (separator > 0) {
-        const teamId = identity.slice(0, separator)
-        const memberName = identity.slice(separator + 1)
-        try {
-          await failMemberOpenAttempt(
-            ctx,
-            join(workspace, stateDir),
-            teamId,
-            memberName,
-            { code: payload.failure.code, message: payload.failure.message },
-            child.session,
-          )
-        } catch (error: unknown) {
-          ctx.logger.warn(`agent-teams: failed to record member turn failure: ${String(error)}`)
-        }
-      }
-      return undefined
+      return next()
     })
     return () => {
       disposeFallback()
       disposeSelection()
+      disposeFailure()
     }
   })
 

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -60,12 +60,15 @@ import {
   memberActivity,
   resolveMemberLlmSelection,
   spawnMember,
+  steerCaptainReport,
   validateMemberLlmSelections,
   type MemberRuntimeConfig,
 } from './members.ts'
 import { TERMINAL_TASK_STATUSES, type TeamMember, type TeamState, type TeamTask } from './types.ts'
 import { installTeamScheduler } from './scheduler.ts'
 import { resolveTeamProfile } from './profiles.ts'
+
+export { steerCaptainReport } from './members.ts'
 
 /** Resolved plugin config consumed by the tools. */
 export interface ToolsConfig {
@@ -407,19 +410,6 @@ export async function haltTeamWork(input: {
   }
 }
 
-export function steerCaptainReport(captain: Pick<Agent, 'steer'>, from: string, content: string): boolean {
-  try {
-    captain.steer(createUserMessage({
-      content: [{ type: 'text', text: `AgentTeams message from member ${from}:\n\n${content}` }],
-      source: { kind: 'plugin', plugin: 'dsh-agent-teams' },
-    }))
-    return true
-  } catch {
-    // The plugin mailbox was persisted before this best-effort live delivery.
-    return false
-  }
-}
-
 /** Context queued after the human rejects a staged plan. */
 export function stagedPlanDiscardContext(teamName: string): string {
   return [
@@ -447,8 +437,10 @@ export function stagedPlanFeedbackContext(teamName: string): string {
  */
 export function registerAgentTeamsTools(ctx: Context, config: ToolsConfig): AgentTeamsRuntime {
   installRetiredMemberGuard(ctx, config.stateDir)
-  const memberSelections = installMemberSelectionRuntime(ctx, config.stateDir)
   const scheduler = installTeamScheduler(ctx, { stateDir: config.stateDir, executionPrompt: config.executionPrompt })
+  const memberSelections = installMemberSelectionRuntime(ctx, config.stateDir, (workspace, teamId, memberName) => (
+    scheduler.kickMember(workspace, teamId, memberName)
+  ))
 
   const updateStagedPlanBatch: AgentTeamsRuntime['updateStagedPlanBatch'] = async (captain, teamId, mutations, signal) => {
     if (mutations.length === 0) throw new Error('at least one staged plan operation is required')


### PR DESCRIPTION
### 一、复现（先于修复）
- 在 `scripts/lifecycle-verify.mjs` 既有夹具上新增 #94 场景：成员无 fallback 配置、领取任务进入 `in_progress`/`working`，其 turn 以 `STREAM_CLOSED`（SSE stream ended without [DONE]）终局且**不产生 idle 边沿**。
- 未修复 main 上断言现状坏行为全部成立（留存输出）：任务停留 `in_progress`、成员停留 `working`、队长邮箱零通知、队长询问消息只排队（deliveries 不增长）——团队静默卡死复现。

### 二、修复（根因 → 最小缝）
- 根因：① `agent/request-error` 钩子仅在配置 fallback 时安装（members.ts 旧 313-314 行）；② 处理器只做路由切换，`STREAM_CLOSED` 不在 `FALLBACK_FAILURE_CODES`（members.ts:128），失败直接上抛，插件侧无任何兜底；③ 调度器恢复全靠 idle 边沿/句柄消失（scheduler.ts:178-181/307/473-485），卡死成员三者皆无；④ 队长询问因闸门不开永远只排队（scheduler.ts:311-333）。
- 改动：钩子**无条件安装**；可经 fallback 恢复的失败保持原重试行为不变，其余失败走新 `failMemberOpenAttempt`：记录错误 → 该成员当前 open attempt **置 `failed`**（claimed/in_progress→failed 为仓内合法转换；不退回 pending 是为避免复现 #66 无界重派环路，仓内尚无重试预算）→ 成员置 `idle`（闸门/flush 可达）→ 队长邮箱收到一条**含错误码与任务 id** 的投递 + `agent-teams/message-sent` 会话事件；全程走既有 `withTeamLock` + `writeTeam` durable 路径。不加 watchdog、不动 parkedAttempts、不碰 #66 恢复预算。

### 三、同 case 验证
- 同一场景断言翻转为修复后好行为：任务 `failed`（output 含 `STREAM_CLOSED`）、成员 `idle`、队长邮箱 +1 条含错误码通知、无任何自动重派（不 own retry），且 harness 结算死 turn 后排队询问恢复可消费——红（未修复 main）→ 绿（本 PR）全程留证。
- 全链：tsc 0 错误；verify.mjs / fallback-tdd / quality-gates-tdd / stress-verify / web-routes / release / sync-skill --check 全绿；lifecycle-verify 的 4 条 #94 检查每轮必绿。另按 #108 做了两处测试夹具稳定化（20ms 等待改轮询、持锁 140→80ms），单列提交、断言不变。

Fixes #94. Related: #66, #108.
