### PR TITLE
Update injected services to include conversationEvents

### DIFF
--- a/src/client/index.tsx
+++ b/src/client/index.tsx
@@ -34,7 +34,7 @@ declare module '@deepseek-ai/dsh-client-ui-slots' {
 }
 
 /** Required services: conversation nodes, slots, sessions navigation, and locale. */
-export const inject = ['uiConversation', 'slots', 'sessions', 'locale', 'modelDirectories']
+export const inject = ['conversationEvents', 'slots', 'sessions', 'locale', 'modelDirectories']
 
 /** The replayed user message is the canonical transcript entry. */
 function HiddenAgentTeamsCommand(): null {
@@ -80,7 +80,7 @@ export function apply(ctx: ClientContext): void {
     key: 'agent-teams',
   }, HiddenAgentTeamsCommand))
 
-  ctx.uiConversation.events.register(agentTeamsCardDefinition)
+  ctx.conversationEvents.register(agentTeamsCardDefinition)
   ctx.slots.inject('conversation.chat.node', () => ctx.slots.register({
     name: 'conversation.chat.node',
     key: 'agent-teams',


### PR DESCRIPTION
### 🐛 问题描述
安装插件后 Harness 启动卡死在检测界面，报错：
`@nanmicoder/dsh-agent-teams: pending (waiting for service: uiConversation)`
`web boot: 1 entry did not activate`

### 🔍 根本原因
Harness 核心架构中实际服务名称为 `conversationEvents`，并不存在 `uiConversation`。
客户端代码声明依赖了不存在的 `uiConversation` 服务导致挂起。

### 🛠️ 解决方案
- 将 `src/client/index.tsx` 中的 `'uiConversation'` 替换为 `'conversationEvents'`
- 将 `ctx.uiConversation.events.register` 修正为 `ctx.conversationEvents.register`