### PR TITLE
feat: expose public AgentTeams bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,34 @@ Defaults work without extra setup. A trusted profile can override member behavio
 
 See [docs/usage.md](./docs/usage.md) for the full tool reference, state model, Web UI behavior, configuration, and known limits.
 
+## Read-only host Bridge
+
+Host plugins can consume the stable Cordis service without importing the
+internal AgentTeams runtime:
+
+```ts
+import type {} from '@nanmicoder/dsh-agent-teams/bridge'
+
+export const inject = ['agentTeamsBridge']
+
+export function apply(ctx: import('@deepseek-ai/cordis').Context): void {
+  ctx.effect(() => ctx.agentTeamsBridge.subscribeTeamEvents(
+    'captain-session-id',
+    (event) => {
+      // event.type is a stable discriminant such as "team-approved".
+    },
+  ))
+}
+```
+
+`ctx.agentTeamsBridge` exposes only `getTeamForCaptain()` and
+`subscribeTeamEvents()`. Snapshots are detached, deeply frozen views of the
+persisted state. Lookup returns `null` when the captain is offline or its
+workspace cannot be located; it never guesses a workspace. Lifecycle events
+are process-local and filtered by captain session. In particular,
+`team-approved` is delivered synchronously after the running state and every
+member child session id are durable, and before the scheduler is kicked.
+
 ## Plugin development Skill
 
 Community upgrade, audit, benchmark, testing and release skills are vendored with a pinned source revision. See [skills/README.md](./skills/README.md) for local rules and [CONTRIBUTING.md](./CONTRIBUTING.md) for the contribution workflow.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Ask in natural language. The plugin provides the team protocol, eleven coordinat
 
 ## Releases
 
-[v0.1.16-rc.1](./release-notes/v0.1.16-rc.1.md) is published on npm `next`, with fixes for startup, member messaging and task collaboration across supported Harness RC / Alpha versions. Choose a version pair below.
+This checkout prepares [v0.1.16-rc.2](./release-notes/v0.1.16-rc.2.md) for npm `next`. It adds the public, read-only AgentTeams Bridge used by companion research and orchestration plugins. Check [GitHub Releases](https://github.com/NanmiCoder/dsh-agent-teams/releases) before installing it.
 
 ## Why AgentTeams?
 
@@ -49,13 +49,13 @@ The conversation card and activity panel use Harness's official locale service. 
 
 ## Install and choose versions
 
-**Recommended pair: DeepSeek Harness `0.1.2-rc.1` + AgentTeams `0.1.16-rc.1`. Both are still prereleases.**
+**Candidate pair: DeepSeek Harness `0.1.2-rc.1` + AgentTeams `0.1.16-rc.2`. Both are still prereleases.**
 
 | Use case | DeepSeek Harness | AgentTeams plugin |
 | --- | --- | --- |
-| **Recommended installation** | **`0.1.2-rc.1`** | **`0.1.16-rc.1`** |
-| Developer Alpha testing | `0.1.2-alpha.5` | `0.1.16-rc.1` |
-| Retaining an older Alpha | `0.1.2-alpha.2` | `0.1.16-rc.1` |
+| **Release candidate** | **`0.1.2-rc.1`** | **`0.1.16-rc.2`** |
+| Developer Alpha testing | `0.1.2-alpha.5` | `0.1.16-rc.2` |
+| Retaining an older Alpha | `0.1.2-alpha.2` | `0.1.16-rc.2` |
 
 ### 1. Install DeepSeek Harness
 
@@ -71,12 +71,12 @@ Skip this if you already run this version. Alpha is opt-in: select an exact Alph
 This installs into the `web` profile. Replace `web` with your actual profile name if different:
 
 ```sh
-dsh plugin --profile web add --save-exact @nanmicoder/dsh-agent-teams@0.1.16-rc.1
+dsh plugin --profile web add --save-exact @nanmicoder/dsh-agent-teams@0.1.16-rc.2
 ```
 
 **After installation, stop and restart Harness for that profile, then refresh the browser.**
 
-The fixed plugin `0.1.16-rc.1` is published on `next`; `latest` still points to `0.1.15`, which targets Alpha.2. Use the exact-version command above. Future plugin prereleases use `next`; only stable plugin releases that pass the full verification matrix may use `latest`.
+Until `0.1.16-rc.2` appears in GitHub Releases and npm, use this checkout rather than the exact-version command above. Plugin prereleases use `next`; `latest` remains on the stable plugin line and is not a compatibility guarantee for this candidate.
 
 > Desktop users must check the app's embedded Harness core; upgrading the global CLI does not upgrade it. For older `0.1.0-*` / `0.1.1-*` or unlisted hosts, keep a working pair and follow the [older-version and diagnostic guide](./docs/maintenance-workflow.md).
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -30,7 +30,7 @@
 
 ## 版本更新
 
-[v0.1.16-rc.1](./release-notes/v0.1.16-rc.1.md) 已发布到 npm `next`，修复 Harness RC / Alpha 的启动、成员消息与任务协作兼容问题。安装版本见下方配对表。
+本 checkout 正在准备发布到 npm `next` 的 [v0.1.16-rc.2](./release-notes/v0.1.16-rc.2.md)。该版本新增供研究与编排插件使用的公开只读 AgentTeams Bridge；安装前请先检查 [GitHub Releases](https://github.com/NanmiCoder/dsh-agent-teams/releases)。
 
 ## 为什么需要 AgentTeams？
 
@@ -48,13 +48,13 @@
 
 ## 安装与版本选择
 
-**推荐组合：DeepSeek Harness `0.1.2-rc.1` + AgentTeams `0.1.16-rc.1`。两者都仍是预发布版本。**
+**候选组合：DeepSeek Harness `0.1.2-rc.1` + AgentTeams `0.1.16-rc.2`。两者都仍是预发布版本。**
 
 | 使用场景 | DeepSeek Harness | AgentTeams 插件 |
 | --- | --- | --- |
-| **推荐安装** | **`0.1.2-rc.1`** | **`0.1.16-rc.1`** |
-| 开发者测试 Alpha | `0.1.2-alpha.5` | `0.1.16-rc.1` |
-| 保留旧 Alpha | `0.1.2-alpha.2` | `0.1.16-rc.1` |
+| **发布候选** | **`0.1.2-rc.1`** | **`0.1.16-rc.2`** |
+| 开发者测试 Alpha | `0.1.2-alpha.5` | `0.1.16-rc.2` |
+| 保留旧 Alpha | `0.1.2-alpha.2` | `0.1.16-rc.2` |
 
 ### 1. 安装 DeepSeek Harness
 
@@ -70,12 +70,12 @@ dsh --version
 以下安装到 `web` profile；使用其他 profile 时，将 `web` 换成实际名称：
 
 ```sh
-dsh plugin --profile web add --save-exact @nanmicoder/dsh-agent-teams@0.1.16-rc.1
+dsh plugin --profile web add --save-exact @nanmicoder/dsh-agent-teams@0.1.16-rc.2
 ```
 
 **安装后，停止并重新启动该 profile 的 Harness 进程，再刷新浏览器。**
 
-插件修复版 `0.1.16-rc.1` 已发布到 `next`；当前 `latest` 仍是面向 Alpha.2 的 `0.1.15`。请使用上面的精确版本命令。后续插件预发布版本继续进入 `next`，通过完整验证的正式版本才进入 `latest`。
+在 GitHub Releases 和 npm 出现 `0.1.16-rc.2` 之前，请使用当前 checkout，不要执行上面的精确版本安装命令。插件预发布版本进入 `next`；`latest` 保持正式插件渠道，也不能作为本候选的兼容保证。
 
 > Desktop 用户需核对应用内置的 Harness 核心；全局 CLI 升级不会升级桌面内核。旧 `0.1.0-*` / `0.1.1-*` 或其他未列出的宿主，请先保留已工作的组合，参考[旧版本与诊断指引](./docs/maintenance-workflow.md)。
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -137,6 +137,32 @@ dsh plugin --profile web add --save-exact @nanmicoder/dsh-agent-teams@0.1.16-rc.
 
 完整工具列表、状态模型、Web UI 行为、配置与已知限制见 [docs/usage.md](./docs/usage.md)。
 
+## 只读 Host Bridge
+
+其他 Host 插件可通过公开子路径消费稳定的 Cordis service，无需导入内部
+AgentTeams runtime：
+
+```ts
+import type {} from '@nanmicoder/dsh-agent-teams/bridge'
+
+export const inject = ['agentTeamsBridge']
+
+export function apply(ctx: import('@deepseek-ai/cordis').Context): void {
+  ctx.effect(() => ctx.agentTeamsBridge.subscribeTeamEvents(
+    'captain-session-id',
+    (event) => {
+      // event.type 是稳定的判别字段，例如 "team-approved"。
+    },
+  ))
+}
+```
+
+`ctx.agentTeamsBridge` 只暴露 `getTeamForCaptain()` 与
+`subscribeTeamEvents()`。返回值是从持久化状态生成的独立、深度冻结投影；队长
+不在线或无法定位其工作区时返回 `null`，不会猜测工作区。生命周期事件仅在当前
+进程内分发，并按队长 session 过滤。`team-approved` 会在 running 状态及全部成员
+child session id 均已持久化后同步调用 listener，且一定早于 scheduler kick。
+
 ## 插件开发 Skill
 
 仓库已引入社区升级、审计、测试和发布 skills，来源与本项目规则见 [skills/README.md](./skills/README.md)，贡献入口见 [CONTRIBUTING.md](./CONTRIBUTING.md)。

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "sync:skill": "node scripts/sync-skill.mjs",
     "verify:skill": "node scripts/sync-skill.mjs --check",
     "verify": "node scripts/verify.mjs && node scripts/fallback-tdd.mjs && node scripts/member-failure-tdd.mjs && node scripts/quality-gates-tdd.mjs && node scripts/lifecycle-verify.mjs && node scripts/stress-verify.mjs && pnpm verify:bridge && pnpm verify:web-routes && pnpm verify:release && pnpm verify:skill && pnpm verify:harness-contract && pnpm verify:http-body && pnpm verify:compatibility",
-    "verify:bridge": "node --test scripts/bridge.test.mjs",
+    "verify:bridge": "tsc -p tsconfig.bridge-test.json && node --test scripts/bridge.test.mjs",
     "prepublishOnly": "pnpm build && pnpm verify",
     "verify:web-routes": "node scripts/web-routes-verify.mjs",
     "verify:release": "node --test scripts/release-metadata.test.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nanmicoder/dsh-agent-teams",
-  "version": "0.1.16-rc.1",
+  "version": "0.1.16-rc.2",
   "description": "AgentTeams for DeepSeek Harness: multi-agent team collaboration (captain, members, tasks with dependencies, messaging) driven by natural language, with a tree monitor in the web GUI",
   "type": "module",
   "main": "lib/index.js",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,10 @@
       "types": "./lib/types/index.d.ts",
       "default": "./lib/index.js"
     },
+    "./bridge": {
+      "types": "./lib/types/bridge.d.ts",
+      "default": "./lib/bridge.js"
+    },
     "./client": {
       "types": "./lib/types/client/index.d.ts",
       "default": "./lib/client.js"
@@ -84,7 +88,8 @@
     "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.client.json --noEmit",
     "sync:skill": "node scripts/sync-skill.mjs",
     "verify:skill": "node scripts/sync-skill.mjs --check",
-    "verify": "node scripts/verify.mjs && node scripts/fallback-tdd.mjs && node scripts/member-failure-tdd.mjs && node scripts/quality-gates-tdd.mjs && node scripts/lifecycle-verify.mjs && node scripts/stress-verify.mjs && pnpm verify:web-routes && pnpm verify:release && pnpm verify:skill && pnpm verify:harness-contract && pnpm verify:http-body && pnpm verify:compatibility",
+    "verify": "node scripts/verify.mjs && node scripts/fallback-tdd.mjs && node scripts/member-failure-tdd.mjs && node scripts/quality-gates-tdd.mjs && node scripts/lifecycle-verify.mjs && node scripts/stress-verify.mjs && pnpm verify:bridge && pnpm verify:web-routes && pnpm verify:release && pnpm verify:skill && pnpm verify:harness-contract && pnpm verify:http-body && pnpm verify:compatibility",
+    "verify:bridge": "node --test scripts/bridge.test.mjs",
     "prepublishOnly": "pnpm build && pnpm verify",
     "verify:web-routes": "node scripts/web-routes-verify.mjs",
     "verify:release": "node --test scripts/release-metadata.test.mjs",

--- a/release-notes/v0.1.16-rc.2.md
+++ b/release-notes/v0.1.16-rc.2.md
@@ -1,0 +1,18 @@
+# AgentTeams v0.1.16-rc.2 — release candidate
+
+This candidate adds the public AgentTeams Bridge for companion DSH plugins. It retains the exact Harness support matrix from rc.1 and is intended for the npm `next` channel.
+
+## Public bridge
+
+- Export `@nanmicoder/dsh-agent-teams/bridge` with a versioned, read-only `AgentTeamsBridge` contract.
+- Provide the Cordis `agentTeamsBridge` service with fiber-owned registration and disposal.
+- Read detached, deeply immutable team projections from durable state without exposing AgentTeams mutation methods.
+- Publish captain-scoped `team-staged`, `team-approved`, `team-halted`, `team-resumed`, `team-archived`, and `task-updated` lifecycle events.
+- Emit approval only after the running team and every durable member session are committed, while still preceding the first scheduler kick.
+- Isolate synchronous listener failures and asynchronous rejections from the team mutation path; keep duplicate subscriptions independently disposable.
+
+## Verification scope
+
+The bridge contract suite covers package exports, Cordis lifecycle cleanup, immutable projections, captain filtering, independent subscriptions, failure isolation, archived-state reads, and approval ordering. The existing lifecycle suite covers automatic and staged creation, approval, scheduler claims, task transitions, halt, resume, discard, delete, and member failure paths. TypeScript host/client checks, build, the full repository verification suite, and npm package-content validation passed under Node 24 during candidate preparation.
+
+This verification does not establish real-provider behavior, native Desktop compatibility, or every operating system. See the existing compatibility matrix and maintenance workflow for the supported host versions and remaining boundaries.

--- a/scripts/bridge-types.test.ts
+++ b/scripts/bridge-types.test.ts
@@ -1,0 +1,11 @@
+import type { AgentTeamsBridgeEventPublisher } from '../src/bridge-runtime.ts'
+
+declare const publisher: AgentTeamsBridgeEventPublisher
+
+void publisher.publishActive('task-updated', '/state', 'team', 'task')
+void publisher.publishActive('team-halted', '/state', 'team')
+
+// @ts-expect-error task-updated events require the affected task id.
+void publisher.publishActive('task-updated', '/state', 'team')
+// @ts-expect-error team lifecycle events cannot accidentally carry a task id.
+void publisher.publishActive('team-halted', '/state', 'team', 'task')

--- a/scripts/bridge.test.mjs
+++ b/scripts/bridge.test.mjs
@@ -1,0 +1,184 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import test from 'node:test'
+import { Context } from '@deepseek-ai/cordis'
+import { installAgentTeamsBridge } from '../lib/bridge-runtime.js'
+import { archiveTeamDir, createTeamDir, writeTeam } from '../lib/state.js'
+
+const packageJson = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8'))
+
+function team(captainSessionId = 'captain-a') {
+  return {
+    id: 'bridge-team',
+    name: 'Bridge Team',
+    description: 'exercise the public projection',
+    captainSessionId,
+    createdAt: 1,
+    phase: 'staged',
+    planReviewState: 'awaiting_review',
+    halted: false,
+    members: [{
+      id: '', name: 'builder', role: 'implementation', joinedAt: 2, status: 'idle',
+      provider: 'fake', model: 'fake-model',
+    }],
+    tasks: [{
+      id: 't1', subject: 'Build', description: 'Implement it', status: 'pending',
+      assignee: 'builder', dependencies: [], attempt: 0, createdAt: 3, updatedAt: 3,
+    }],
+    taskSeq: 1,
+  }
+}
+
+async function fixture(t) {
+  const workspace = await mkdtemp(join(tmpdir(), 'agent-teams-bridge-'))
+  t.after(() => rm(workspace, { recursive: true, force: true }))
+  const stateRoot = join(workspace, '.agent-teams')
+  const agents = new Map([
+    ['captain-a', { id: 'captain-a', session: { header: { cwd: workspace } } }],
+    ['captain-b', { id: 'captain-b', session: { header: { cwd: workspace } } }],
+    ['captain-no-workspace', { id: 'captain-no-workspace', session: { header: {} } }],
+  ])
+  const warnings = []
+  const ctx = new Context()
+  const disposeAgents = ctx.provide('agents', { get: id => agents.get(id) })
+  t.after(disposeAgents)
+  let publisher
+  const fiber = ctx.plugin((pluginCtx) => {
+    pluginCtx.logger.warn = message => warnings.push(String(message))
+    publisher = installAgentTeamsBridge(pluginCtx, { stateDir: '.agent-teams' })
+  })
+  await fiber
+  t.after(() => fiber.dispose())
+  assert.ok(publisher, 'the test plugin keeps its internal publisher on its own context')
+  return { workspace, stateRoot, agents, warnings, ctx, fiber, publisher, bridge: ctx.agentTeamsBridge }
+}
+
+test('package exposes the stable bridge subpath and build outputs', () => {
+  assert.deepEqual(packageJson.exports['./bridge'], {
+    types: './lib/types/bridge.d.ts',
+    default: './lib/bridge.js',
+  })
+  assert.doesNotThrow(() => readFileSync(new URL('../lib/bridge.js', import.meta.url)))
+  assert.doesNotThrow(() => readFileSync(new URL('../lib/types/bridge.d.ts', import.meta.url)))
+})
+
+test('Cordis service follows the owning fiber lifecycle', async (t) => {
+  const { ctx, fiber, bridge } = await fixture(t)
+  assert.equal(bridge.apiVersion, 1)
+  assert.deepEqual(
+    Object.keys(bridge).sort(),
+    ['apiVersion', 'getTeamForCaptain', 'subscribeTeamEvents'],
+    'the public service surface is read-only',
+  )
+  assert.equal(Object.isFrozen(bridge), true)
+  await fiber.dispose()
+  assert.equal(ctx.get('agentTeamsBridge'), undefined)
+})
+
+test('projection is a detached deeply immutable disk snapshot and never guesses a workspace', async (t) => {
+  const { stateRoot, agents, bridge } = await fixture(t)
+  const durable = team()
+  await createTeamDir(stateRoot, durable)
+  const projection = await bridge.getTeamForCaptain('captain-a')
+  assert.equal(projection?.id, durable.id)
+  assert.equal(projection?.phase, 'staged')
+  assert.equal(Object.isFrozen(projection), true)
+  assert.equal(Object.isFrozen(projection.members), true)
+  assert.equal(Object.isFrozen(projection.members[0]), true)
+  assert.equal(Object.isFrozen(projection.tasks[0].dependencies), true)
+  assert.throws(() => { projection.members[0].name = 'mutated' }, TypeError)
+  durable.members[0].name = 'changed only in caller memory'
+  assert.equal(projection.members[0].name, 'builder')
+  assert.equal(await bridge.getTeamForCaptain('captain-no-workspace'), null)
+  agents.delete('captain-a')
+  assert.equal(await bridge.getTeamForCaptain('captain-a'), null)
+})
+
+test('subscriptions filter captains, isolate listener failures, and dispose idempotently', async (t) => {
+  const { stateRoot, warnings, bridge, publisher } = await fixture(t)
+  await createTeamDir(stateRoot, team())
+  const observed = []
+  const disposeA = bridge.subscribeTeamEvents('captain-a', event => observed.push(event.type))
+  bridge.subscribeTeamEvents('captain-a', () => { throw new Error('listener boom') })
+  bridge.subscribeTeamEvents('captain-a', async () => { throw new Error('async listener boom') })
+  bridge.subscribeTeamEvents('captain-b', event => observed.push(`wrong:${event.type}`))
+  await publisher.publishActive('team-staged', stateRoot, 'bridge-team')
+  await new Promise(resolve => setImmediate(resolve))
+  assert.deepEqual(observed, ['team-staged'])
+  assert.match(warnings.join('\n'), /listener boom/)
+  assert.match(warnings.join('\n'), /async listener boom/)
+  disposeA()
+  disposeA()
+  await publisher.publishActive('team-staged', stateRoot, 'bridge-team')
+  assert.deepEqual(observed, ['team-staged'])
+})
+
+test('publisher emits all lifecycle variants from durable active or archived truth', async (t) => {
+  const { stateRoot, bridge, publisher } = await fixture(t)
+  const durable = team()
+  await createTeamDir(stateRoot, durable)
+  const events = []
+  bridge.subscribeTeamEvents('captain-a', event => events.push(event))
+
+  await publisher.publishActive('team-staged', stateRoot, durable.id)
+  durable.phase = 'running'
+  durable.approvedAt = 10
+  durable.members[0].id = 'durable-child-session'
+  await writeTeam(stateRoot, durable)
+  await publisher.publishActive('team-approved', stateRoot, durable.id)
+  durable.halted = true
+  await writeTeam(stateRoot, durable)
+  await publisher.publishActive('team-halted', stateRoot, durable.id)
+  durable.halted = false
+  await writeTeam(stateRoot, durable)
+  await publisher.publishActive('team-resumed', stateRoot, durable.id)
+  durable.tasks[0].status = 'completed'
+  durable.tasks[0].output = 'done'
+  await writeTeam(stateRoot, durable)
+  await publisher.publishActive('task-updated', stateRoot, durable.id, durable.tasks[0].id)
+  await archiveTeamDir(stateRoot, durable.id)
+  await publisher.publishArchived(stateRoot, durable.id)
+
+  assert.deepEqual(events.map(event => event.type), [
+    'team-staged', 'team-approved', 'team-halted', 'team-resumed', 'task-updated', 'team-archived',
+  ])
+  for (const event of events) {
+    assert.equal(event.apiVersion, 1)
+    assert.equal(event.teamId, durable.id)
+    assert.equal(event.captainSessionId, 'captain-a')
+  }
+  const approved = events[1]
+  assert.equal(approved.team.phase, 'running')
+  assert.equal(approved.team.members[0].id, 'durable-child-session')
+  const taskUpdated = events[4]
+  assert.equal(taskUpdated.task.id, 't1')
+  assert.equal(taskUpdated.task.status, 'completed')
+  assert.equal(events[5].team.phase, 'running')
+})
+
+test('approved event refuses staged state and observes durable member ids', async (t) => {
+  const { stateRoot, bridge, publisher } = await fixture(t)
+  const durable = team()
+  await createTeamDir(stateRoot, durable)
+  const events = []
+  bridge.subscribeTeamEvents('captain-a', event => events.push(event))
+  await publisher.publishActive('team-approved', stateRoot, durable.id)
+  assert.deepEqual(events, [])
+  durable.phase = 'running'
+  durable.members[0].id = 'durable-child-session'
+  await writeTeam(stateRoot, durable)
+  await publisher.publishActive('team-approved', stateRoot, durable.id)
+  assert.deepEqual(events.map(event => event.type), ['team-approved'])
+})
+
+test('projection read failures are observational and cannot reject the team mutation path', async (t) => {
+  const { stateRoot, warnings, publisher } = await fixture(t)
+  await mkdir(join(stateRoot, 'broken-team'), { recursive: true })
+  await writeFile(join(stateRoot, 'broken-team', 'team.json'), '{broken json')
+  await assert.doesNotReject(publisher.publishActive('team-halted', stateRoot, 'broken-team'))
+  await assert.doesNotReject(publisher.publishArchived(stateRoot, 'broken-team'))
+  assert.match(warnings.join('\n'), /bridge.*projection.*failed/i)
+})

--- a/scripts/bridge.test.mjs
+++ b/scripts/bridge.test.mjs
@@ -116,6 +116,25 @@ test('subscriptions filter captains, isolate listener failures, and dispose idem
   assert.deepEqual(observed, ['team-staged'])
 })
 
+test('duplicate listener subscriptions are independent registrations', async (t) => {
+  const { stateRoot, bridge, publisher } = await fixture(t)
+  await createTeamDir(stateRoot, team())
+  const observed = []
+  const listener = event => observed.push(event.type)
+  const disposeFirst = bridge.subscribeTeamEvents('captain-a', listener)
+  const disposeSecond = bridge.subscribeTeamEvents('captain-a', listener)
+
+  await publisher.publishActive('team-staged', stateRoot, 'bridge-team')
+  assert.deepEqual(observed, ['team-staged', 'team-staged'])
+  disposeFirst()
+  await publisher.publishActive('team-staged', stateRoot, 'bridge-team')
+  assert.deepEqual(observed, ['team-staged', 'team-staged', 'team-staged'])
+  disposeFirst()
+  disposeSecond()
+  await publisher.publishActive('team-staged', stateRoot, 'bridge-team')
+  assert.deepEqual(observed, ['team-staged', 'team-staged', 'team-staged'])
+})
+
 test('publisher emits all lifecycle variants from durable active or archived truth', async (t) => {
   const { stateRoot, bridge, publisher } = await fixture(t)
   const durable = team()
@@ -179,6 +198,10 @@ test('projection read failures are observational and cannot reject the team muta
   await mkdir(join(stateRoot, 'broken-team'), { recursive: true })
   await writeFile(join(stateRoot, 'broken-team', 'team.json'), '{broken json')
   await assert.doesNotReject(publisher.publishActive('team-halted', stateRoot, 'broken-team'))
-  await assert.doesNotReject(publisher.publishArchived(stateRoot, 'broken-team'))
-  assert.match(warnings.join('\n'), /bridge.*projection.*failed/i)
+  assert.match(warnings.at(-1), /bridge.*projection.*failed.*team-halted/i)
+
+  await mkdir(join(stateRoot, 'archive', 'broken-archive'), { recursive: true })
+  await writeFile(join(stateRoot, 'archive', 'broken-archive', 'team.json'), '{broken archive json')
+  await assert.doesNotReject(publisher.publishArchived(stateRoot, 'broken-archive'))
+  assert.match(warnings.at(-1), /bridge.*projection.*failed.*team-archived/i)
 })

--- a/scripts/lifecycle-verify.mjs
+++ b/scripts/lifecycle-verify.mjs
@@ -30,6 +30,22 @@ const childListeners = new Map()
 const continuableSetups = []
 const failNextDelivery = new Set()
 const failures = []
+const bridgeEvents = []
+const bridgePublisher = {
+  async publishActive(type, eventStateRoot, eventTeamId, taskId) {
+    bridgeEvents.push({
+      type,
+      team: structuredClone(await readTeam(eventStateRoot, eventTeamId)),
+      taskId,
+    })
+  },
+  async publishArchived(eventStateRoot, eventTeamId) {
+    bridgeEvents.push({
+      type: 'team-archived',
+      team: structuredClone(await readArchivedTeam(eventStateRoot, eventTeamId)),
+    })
+  },
+}
 let childSeq = 0
 let messageSeq = 0
 
@@ -271,6 +287,7 @@ const agentTeamsRuntime = registerAgentTeamsTools(ctx, {
   fallback: { provider: 'backup', model: 'backup-model' },
   memberMaxDepth: 1,
   maxMembers: 8,
+  bridgeEvents: bridgePublisher,
   profiles: {
     'demo-delivery': {
       description: 'tiny delivery team',
@@ -435,6 +452,11 @@ try {
     profile: 'demo-delivery',
   })
   const profileTeam = await readTeam(stateRoot, 'profile-demo')
+  check('automatic create emits running semantics from durable state',
+    bridgeEvents.some(event => event.type === 'team-approved'
+      && event.team?.id === 'profile-demo'
+      && event.team.phase === 'running'
+      && event.team.members.every(member => member.id !== '')))
   check('create(profile) returns profile members tasks and seed ids',
     createdProfile.profile === 'demo-delivery'
       && createdProfile.members?.length === 2
@@ -457,6 +479,11 @@ try {
     firstSeed?.status === 'claimed' && firstSeed.assignee === 'analyst'
       && deliveries.some(delivery => delivery.childId === analyst.id)
       && !deliveries.some(delivery => delivery.childId === implementer.id && String(delivery.content?.[0]?.text ?? '').includes('Implement')))
+  check('scheduler claim emits a durable task-updated bridge event',
+    bridgeEvents.some(event => event.type === 'task-updated'
+      && event.team?.id === 'profile-demo'
+      && event.taskId === firstSeed?.id
+      && event.team.tasks.find(task => task.id === firstSeed?.id)?.status === 'claimed'))
   const firstAssignment = deliveries.find(delivery => delivery.childId === analyst.id)
   const assignmentText = Array.isArray(firstAssignment?.content)
     ? firstAssignment.content.map(block => block.text ?? '').join('\n')
@@ -509,6 +536,11 @@ try {
     profileStatus.profile?.name === 'demo-delivery'
       && profileStatus.tasks.some(item => item.seed_id === 'requirements')
       && profileStatus.tasks.some(item => item.seed_id === 'implement'))
+  check('task transitions publish their durable task projection',
+    bridgeEvents.some(event => event.type === 'task-updated'
+      && event.team?.id === 'profile-demo'
+      && event.taskId === firstSeed.id
+      && event.team.tasks.find(task => task.id === firstSeed.id)?.status === 'completed'))
   await call('agent_teams_delete', {})
 
   const deliveriesBeforeDiscard = deliveries.length
@@ -530,6 +562,9 @@ try {
       && discardedArchive.members.every(member => member.id === '')
       && discardedArchive.tasks.every(task => task.status === 'pending')
       && deliveries.length === deliveriesBeforeDiscard)
+  check('staged create and discard emit staged then archived lifecycle events',
+    bridgeEvents.some(event => event.type === 'team-staged' && event.team?.id === 'rejected-demo')
+      && bridgeEvents.some(event => event.type === 'team-archived' && event.team?.id === 'rejected-demo'))
   const discardControlText = captain.injections.at(-1)?.content?.map(block => block.text ?? '').join('\n') ?? ''
   check('discard aborts the active Captain turn and parks an authoritative no-recreate context',
     (captain.cancelCount ?? 0) === captainCancelsBeforeDiscard + 1
@@ -657,6 +692,7 @@ try {
       && deliveries.length === deliveriesBeforePlan)
   const approvedDynamic = await call('agent_teams_approve', { confirmation: 'user clicked Approve & Run' })
   const dynamicTeam = await readTeam(stateRoot, 'dynamic-demo')
+  const approvedBridgeEvent = bridgeEvents.find(event => event.type === 'team-approved' && event.team?.id === 'dynamic-demo')
   check('approval atomically spawns the final roster before dispatch',
     approvedDynamic.status === 'running'
       && dynamicTeam?.phase === 'running'
@@ -664,6 +700,11 @@ try {
       && dynamicTeam.members.every(member => member.id !== '')
       && dynamicTeam.tasks[0]?.status === 'pending'
       && dynamicTeam.tasks[1]?.status === 'pending')
+  check('approved bridge event observes the committed running roster before later scheduler work',
+    approvedBridgeEvent?.team?.phase === 'running'
+      && typeof approvedBridgeEvent.team.approvedAt === 'number'
+      && approvedBridgeEvent.team.members.every(member => member.id !== '')
+      && approvedBridgeEvent.team.tasks.every(task => task.status === 'pending'))
   for (const member of dynamicTeam.members) publishStatus(liveAgents.get(member.id), 'idle')
   await call('agent_teams_status', {})
   const dispatchedDynamic = await readTeam(stateRoot, 'dynamic-demo')
@@ -680,6 +721,7 @@ try {
     teamId: 'dynamic-demo',
     captain,
     signal: new AbortController().signal,
+    bridgeEvents: bridgePublisher,
   })
   const haltedTeam = await readTeam(stateRoot, 'dynamic-demo')
   check('captain halt cancels the approved graph and keeps the team',
@@ -687,6 +729,11 @@ try {
       && halt.cancelledTasks === 2
       && haltedTeam?.halted === true
       && haltedTeam.tasks.every(item => item.status === 'cancelled'))
+  check('halt publishes the durable cancelled projection',
+    bridgeEvents.some(event => event.type === 'team-halted'
+      && event.team?.id === 'dynamic-demo'
+      && event.team.halted === true
+      && event.team.tasks.every(task => task.status === 'cancelled')))
   check('team halt cancels the captain turn while preserving queued user input',
     captain.cancelCount === captainCancelsBeforeHalt + 2
       && captain.lastCancel?.cause?.kind === 'user'
@@ -717,11 +764,17 @@ try {
     resume.status === 'resumed'
       && (await readTeam(stateRoot, 'dynamic-demo'))?.halted !== true
       && (await readTeam(stateRoot, 'dynamic-demo'))?.tasks.every(item => item.status === 'cancelled'))
+  check('resume publishes the durable unhalted projection',
+    bridgeEvents.some(event => event.type === 'team-resumed'
+      && event.team?.id === 'dynamic-demo'
+      && event.team.halted !== true))
   await call('agent_teams_delete', {})
   const haltedArchive = await readArchivedTeam(stateRoot, 'dynamic-demo')
   check('shutdown preserves cancelled task history in the archive',
     haltedArchive?.tasks.length === 2
       && haltedArchive.tasks.every(item => item.status === 'cancelled'))
+  check('delete publishes the archived durable projection',
+    bridgeEvents.some(event => event.type === 'team-archived' && event.team?.id === 'dynamic-demo'))
 
   await call('agent_teams_create', { name: 'Quality Loop', description: 'review loop' })
   await call('agent_teams_add_member', { name: 'builder', role: 'implementer' })

--- a/src/bridge-runtime.ts
+++ b/src/bridge-runtime.ts
@@ -14,10 +14,13 @@ import { findTeamByCaptain, readArchivedTeam, readTeam } from './state.ts'
 import type { TeamState, TeamTask } from './types.ts'
 
 export type ActiveBridgeEventType = Exclude<TeamLifecycleEvent['type'], 'team-archived'>
+export type ActiveBridgeEventArgs =
+  | readonly [type: 'task-updated', stateRoot: string, teamId: string, taskId: string]
+  | readonly [type: Exclude<ActiveBridgeEventType, 'task-updated'>, stateRoot: string, teamId: string]
 
 /** Internal write-side of the event bus; never installed on the Cordis context. */
 export interface AgentTeamsBridgeEventPublisher {
-  publishActive(type: ActiveBridgeEventType, stateRoot: string, teamId: string, taskId?: string): Promise<void>
+  publishActive(...args: ActiveBridgeEventArgs): Promise<void>
   publishArchived(stateRoot: string, teamId: string): Promise<void>
 }
 
@@ -26,6 +29,9 @@ interface BridgeConfig {
 }
 
 type Listener = (event: TeamLifecycleEvent) => void
+interface ListenerRegistration {
+  readonly listener: Listener
+}
 
 function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
   return (typeof value === 'object' && value !== null) || typeof value === 'function'
@@ -80,7 +86,7 @@ export function projectTeam(team: TeamState): TeamProjection {
 
 /** Register the public service and return its private event write-side. */
 export function installAgentTeamsBridge(ctx: Context, config: BridgeConfig): AgentTeamsBridgeEventPublisher {
-  const listenersByCaptain = new Map<string, Set<Listener>>()
+  const listenersByCaptain = new Map<string, Set<ListenerRegistration>>()
   const publish = (type: TeamLifecycleEvent['type'], state: TeamState, taskId?: string): void => {
     const team = projectTeam(state)
     let event: TeamLifecycleEvent
@@ -104,9 +110,9 @@ export function installAgentTeamsBridge(ctx: Context, config: BridgeConfig): Age
         team,
       }) as TeamLifecycleEvent
     }
-    for (const listener of [...(listenersByCaptain.get(team.captainSessionId) ?? [])]) {
+    for (const registration of [...(listenersByCaptain.get(team.captainSessionId) ?? [])]) {
       try {
-        const result = (listener as (value: TeamLifecycleEvent) => unknown)(event)
+        const result = (registration.listener as (value: TeamLifecycleEvent) => unknown)(event)
         if (isPromiseLike(result)) {
           void Promise.resolve(result).catch((error: unknown) => {
             ctx.logger.warn(`agent-teams bridge listener failed after ${type}: ${String(error)}`)
@@ -128,14 +134,15 @@ export function installAgentTeamsBridge(ctx: Context, config: BridgeConfig): Age
       return team === undefined ? null : projectTeam(team)
     },
     subscribeTeamEvents(captainSessionId: string, listener: Listener): () => void {
-      const listeners = listenersByCaptain.get(captainSessionId) ?? new Set<Listener>()
-      listeners.add(listener)
+      const listeners = listenersByCaptain.get(captainSessionId) ?? new Set<ListenerRegistration>()
+      const registration = { listener }
+      listeners.add(registration)
       listenersByCaptain.set(captainSessionId, listeners)
       let disposed = false
       return () => {
         if (disposed) return
         disposed = true
-        listeners.delete(listener)
+        listeners.delete(registration)
         if (listeners.size === 0) listenersByCaptain.delete(captainSessionId)
       }
     },
@@ -143,7 +150,8 @@ export function installAgentTeamsBridge(ctx: Context, config: BridgeConfig): Age
   ctx.provide('agentTeamsBridge', bridge)
 
   return {
-    publishActive: async (type, stateRoot, teamId, taskId) => {
+    publishActive: async (...args) => {
+      const [type, stateRoot, teamId, taskId] = args
       try {
         const team = await readTeam(stateRoot, teamId)
         if (team === undefined) return

--- a/src/bridge-runtime.ts
+++ b/src/bridge-runtime.ts
@@ -1,0 +1,169 @@
+/** Internal implementation of the public AgentTeams Bridge service. */
+
+import type { Context } from '@deepseek-ai/cordis'
+import type {} from '@deepseek-ai/dsh-agent'
+import type { SessionId } from '@deepseek-ai/dsh-session'
+import { join } from 'node:path'
+import type {
+  AgentTeamsBridge,
+  TeamLifecycleEvent,
+  TeamProjection,
+  TeamTaskProjection,
+} from './bridge.ts'
+import { findTeamByCaptain, readArchivedTeam, readTeam } from './state.ts'
+import type { TeamState, TeamTask } from './types.ts'
+
+export type ActiveBridgeEventType = Exclude<TeamLifecycleEvent['type'], 'team-archived'>
+
+/** Internal write-side of the event bus; never installed on the Cordis context. */
+export interface AgentTeamsBridgeEventPublisher {
+  publishActive(type: ActiveBridgeEventType, stateRoot: string, teamId: string, taskId?: string): Promise<void>
+  publishArchived(stateRoot: string, teamId: string): Promise<void>
+}
+
+interface BridgeConfig {
+  readonly stateDir: string
+}
+
+type Listener = (event: TeamLifecycleEvent) => void
+
+function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
+  return (typeof value === 'object' && value !== null) || typeof value === 'function'
+    ? typeof (value as { then?: unknown }).then === 'function'
+    : false
+}
+
+function freezeTask(task: TeamTask): TeamTaskProjection {
+  return Object.freeze({
+    id: task.id,
+    subject: task.subject,
+    ...task.description === undefined ? {} : { description: task.description },
+    status: task.status,
+    ...task.assignee === undefined ? {} : { assignee: task.assignee },
+    dependencies: Object.freeze([...task.dependencies]),
+    ...task.output === undefined ? {} : { output: task.output },
+    ...task.attempt === undefined ? {} : { attempt: task.attempt },
+    ...task.attemptId === undefined ? {} : { attemptId: task.attemptId },
+    ...task.kind === undefined ? {} : { kind: task.kind },
+    ...task.round === undefined ? {} : { round: task.round },
+    ...task.verdict === undefined ? {} : { verdict: task.verdict },
+    createdAt: task.createdAt,
+    updatedAt: task.updatedAt,
+  })
+}
+
+/** Convert mutable internal state into a detached, deeply frozen public view. */
+export function projectTeam(team: TeamState): TeamProjection {
+  const members = team.members.map(member => Object.freeze({
+    id: member.id,
+    name: member.name,
+    ...member.role === undefined ? {} : { role: member.role },
+    ...member.provider === undefined ? {} : { provider: member.provider },
+    ...member.model === undefined ? {} : { model: member.model },
+    ...member.reasoningEffort === undefined ? {} : { reasoningEffort: member.reasoningEffort },
+    joinedAt: member.joinedAt,
+    status: member.status,
+  }))
+  return Object.freeze({
+    id: team.id,
+    name: team.name,
+    ...team.description === undefined ? {} : { description: team.description },
+    captainSessionId: team.captainSessionId,
+    phase: team.phase ?? 'running',
+    halted: team.halted === true,
+    approvedAt: team.approvedAt,
+    createdAt: team.createdAt,
+    members: Object.freeze(members),
+    tasks: Object.freeze(team.tasks.map(freezeTask)),
+  })
+}
+
+/** Register the public service and return its private event write-side. */
+export function installAgentTeamsBridge(ctx: Context, config: BridgeConfig): AgentTeamsBridgeEventPublisher {
+  const listenersByCaptain = new Map<string, Set<Listener>>()
+  const publish = (type: TeamLifecycleEvent['type'], state: TeamState, taskId?: string): void => {
+    const team = projectTeam(state)
+    let event: TeamLifecycleEvent
+    if (type === 'task-updated') {
+      const task = team.tasks.find(candidate => candidate.id === taskId)
+      if (task === undefined) return
+      event = Object.freeze({
+        apiVersion: 1,
+        teamId: team.id,
+        captainSessionId: team.captainSessionId,
+        type,
+        team,
+        task,
+      })
+    } else {
+      event = Object.freeze({
+        apiVersion: 1,
+        teamId: team.id,
+        captainSessionId: team.captainSessionId,
+        type,
+        team,
+      }) as TeamLifecycleEvent
+    }
+    for (const listener of [...(listenersByCaptain.get(team.captainSessionId) ?? [])]) {
+      try {
+        const result = (listener as (value: TeamLifecycleEvent) => unknown)(event)
+        if (isPromiseLike(result)) {
+          void Promise.resolve(result).catch((error: unknown) => {
+            ctx.logger.warn(`agent-teams bridge listener failed after ${type}: ${String(error)}`)
+          })
+        }
+      } catch (error: unknown) {
+        ctx.logger.warn(`agent-teams bridge listener failed after ${type}: ${String(error)}`)
+      }
+    }
+  }
+
+  const bridge: AgentTeamsBridge = Object.freeze({
+    apiVersion: 1 as const,
+    async getTeamForCaptain(captainSessionId: string): Promise<TeamProjection | null> {
+      const captain = ctx.agents.get(captainSessionId as SessionId)
+      const workspace = captain?.session.header.cwd
+      if (workspace === undefined || workspace.trim() === '') return null
+      const team = await findTeamByCaptain(join(workspace, config.stateDir), captainSessionId)
+      return team === undefined ? null : projectTeam(team)
+    },
+    subscribeTeamEvents(captainSessionId: string, listener: Listener): () => void {
+      const listeners = listenersByCaptain.get(captainSessionId) ?? new Set<Listener>()
+      listeners.add(listener)
+      listenersByCaptain.set(captainSessionId, listeners)
+      let disposed = false
+      return () => {
+        if (disposed) return
+        disposed = true
+        listeners.delete(listener)
+        if (listeners.size === 0) listenersByCaptain.delete(captainSessionId)
+      }
+    },
+  })
+  ctx.provide('agentTeamsBridge', bridge)
+
+  return {
+    publishActive: async (type, stateRoot, teamId, taskId) => {
+      try {
+        const team = await readTeam(stateRoot, teamId)
+        if (team === undefined) return
+        if (type === 'team-approved' && (
+          team.phase !== 'running'
+          || team.members.some(member => member.status !== 'removed' && member.id === '')
+        )) return
+        publish(type, team, taskId)
+      } catch (error: unknown) {
+        ctx.logger.warn(`agent-teams bridge projection failed after ${type}: ${String(error)}`)
+      }
+    },
+    publishArchived: async (stateRoot, teamId) => {
+      try {
+        const team = await readArchivedTeam(stateRoot, teamId)
+        if (team === undefined) return
+        publish('team-archived', team)
+      } catch (error: unknown) {
+        ctx.logger.warn(`agent-teams bridge projection failed after team-archived: ${String(error)}`)
+      }
+    },
+  }
+}

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -1,0 +1,118 @@
+/**
+ * Public, read-only AgentTeams integration contract.
+ *
+ * Consumers should import this module through
+ * `@nanmicoder/dsh-agent-teams/bridge` and inject `agentTeamsBridge` from
+ * Cordis. Team mutation remains exclusively owned by the AgentTeams tools.
+ * @module dsh-agent-teams/bridge
+ */
+
+/** Public API version carried by the service and every lifecycle event. */
+export type AgentTeamsBridgeApiVersion = 1
+
+/** Read-only projection of one durable team member. */
+export interface TeamMemberProjection {
+  readonly id: string
+  readonly name: string
+  readonly role?: string
+  readonly provider?: string
+  readonly model?: string
+  readonly reasoningEffort?: string
+  readonly joinedAt: number
+  readonly status: 'idle' | 'working' | 'removed'
+}
+
+/** Read-only projection of one durable team task. */
+export interface TeamTaskProjection {
+  readonly id: string
+  readonly subject: string
+  readonly description?: string
+  readonly status: 'pending' | 'claimed' | 'in_progress' | 'completed' | 'failed' | 'cancelled'
+  readonly assignee?: string
+  readonly dependencies: readonly string[]
+  readonly output?: string
+  readonly attempt?: number
+  readonly attemptId?: string
+  readonly kind?: 'requirements' | 'implementation' | 'verification' | 'review' | 'repair' | 'integration' | 'work'
+  readonly round?: number
+  readonly verdict?: 'pass' | 'needs_revision' | 'reject'
+  readonly createdAt: number
+  readonly updatedAt: number
+}
+
+/** Detached read-only snapshot of the persisted team state. */
+export interface TeamProjection {
+  readonly id: string
+  readonly name: string
+  readonly description?: string
+  readonly captainSessionId: string
+  readonly phase: 'staged' | 'running'
+  readonly halted: boolean
+  readonly approvedAt?: number
+  readonly createdAt: number
+  readonly members: readonly TeamMemberProjection[]
+  readonly tasks: readonly TeamTaskProjection[]
+}
+
+interface TeamLifecycleEventBase {
+  readonly apiVersion: AgentTeamsBridgeApiVersion
+  readonly teamId: string
+  readonly captainSessionId: string
+}
+
+export interface TeamStagedEvent extends TeamLifecycleEventBase {
+  readonly type: 'team-staged'
+  readonly team: TeamProjection
+}
+
+export interface TeamApprovedEvent extends TeamLifecycleEventBase {
+  readonly type: 'team-approved'
+  readonly team: TeamProjection
+}
+
+export interface TeamHaltedEvent extends TeamLifecycleEventBase {
+  readonly type: 'team-halted'
+  readonly team: TeamProjection
+}
+
+export interface TeamResumedEvent extends TeamLifecycleEventBase {
+  readonly type: 'team-resumed'
+  readonly team: TeamProjection
+}
+
+export interface TeamArchivedEvent extends TeamLifecycleEventBase {
+  readonly type: 'team-archived'
+  readonly team: TeamProjection
+}
+
+export interface TaskUpdatedEvent extends TeamLifecycleEventBase {
+  readonly type: 'task-updated'
+  readonly team: TeamProjection
+  readonly task: TeamTaskProjection
+}
+
+/** Stable discriminated union of process-local lifecycle notifications. */
+export type TeamLifecycleEvent =
+  | TeamStagedEvent
+  | TeamApprovedEvent
+  | TeamHaltedEvent
+  | TeamResumedEvent
+  | TeamArchivedEvent
+  | TaskUpdatedEvent
+
+/** Minimal read-only service exposed on the host Cordis context. */
+export interface AgentTeamsBridge {
+  readonly apiVersion: 1
+  getTeamForCaptain(captainSessionId: string): Promise<TeamProjection | null>
+  subscribeTeamEvents(
+    captainSessionId: string,
+    listener: (event: TeamLifecycleEvent) => void,
+  ): () => void
+}
+
+declare module '@deepseek-ai/cordis' {
+  interface Context {
+    /** Read-only AgentTeams integration surface. */
+    agentTeamsBridge: AgentTeamsBridge
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,7 @@ import { collectArchivedTeamsActivity, collectTeamsActivity } from './snapshot.t
 import { findTeamByCaptain } from './state.ts'
 import { formatProfilesForPrompt, type TeamProfileConfig } from './profiles.ts'
 import { qualityPlanningPrompt } from './quality-gates.ts'
+import { installAgentTeamsBridge } from './bridge-runtime.ts'
 
 import { authenticatedWebRoutes, readJsonRequest, RequestBodyError, type BrowserRequestGate, type WebRouteHost } from './web-routes.ts'
 
@@ -158,6 +159,9 @@ export function apply(ctx: Context, config: Config): void {
     maxMembers: config.maxMembers ?? 8,
     profiles: config.profiles ?? {},
   }
+
+  const bridgeEvents = installAgentTeamsBridge(ctx, { stateDir: resolved.stateDir })
+  resolved.bridgeEvents = bridgeEvents
 
   // Provider registration is a sibling plugin's effect (`subagent-spawn` /
   // `subagent-fork` rows), which can land after this mount under the Loader's
@@ -290,6 +294,7 @@ export function apply(ctx: Context, config: Config): void {
             stateRoot,
             teamId,
             captain,
+            bridgeEvents,
           })
           res.writeHead(200, { 'content-type': 'application/json; charset=utf-8', 'cache-control': 'no-store' })
           res.end(JSON.stringify(result))

--- a/src/members.ts
+++ b/src/members.ts
@@ -23,6 +23,7 @@ import { guardSubagentDelivery, installContinuableMemberSetup, queueMemberPrompt
 import { acknowledgeMailbox, appendMailbox, CAPTAIN_KEY, createMessage, readRetiredMemberIds, readTeamSync, readTeam, releaseMailboxDelivery, withTeamLock, writeTeam } from './state.ts'
 import { appendTeamEvent, captainSessionOf } from './events.ts'
 import { TERMINAL_TASK_STATUSES, type TeamMember, type TeamState, type TeamTask } from './types.ts'
+import type { AgentTeamsBridgeEventPublisher } from './bridge-runtime.ts'
 
 /** Persona snapshot of a profile protocol; the full text lives on team.json. */
 export const PERSONA_PROTOCOL_MAX_CHARS = 400
@@ -173,6 +174,7 @@ export async function failMemberOpenAttempt(
   failure: { readonly code: string; readonly message: string },
   fallbackSession: Session,
   observed: FailedMemberAttempt,
+  bridgeEvents?: AgentTeamsBridgeEventPublisher,
 ): Promise<boolean> {
   const summary = `${failure.message} (code ${failure.code})`
   const lockKey = `team:${stateRoot}:${teamId}`
@@ -202,6 +204,7 @@ export async function failMemberOpenAttempt(
       deliveryClaimedAt: Date.now(),
     }
     await writeTeam(stateRoot, team)
+    if (task !== undefined) await bridgeEvents?.publishActive('task-updated', stateRoot, team.id, task.id)
     await appendMailbox(stateRoot, team.id, CAPTAIN_KEY, message)
     if (task !== undefined) {
       appendTeamEvent(ctx, captainSessionOf(ctx, team.captainSessionId, fallbackSession), 'agent-teams/task-updated', {
@@ -364,6 +367,7 @@ export function installMemberSelectionRuntime(
   ctx: Context,
   stateDir: string,
   onFailureSettled?: (workspace: string, teamId: string, memberName: string) => Promise<void>,
+  bridgeEvents?: AgentTeamsBridgeEventPublisher,
 ): MemberSelectionRuntime {
   const pending = new Map<string, MemberLlmSelection>()
   installContinuableMemberSetup(ctx, (childCtx) => {
@@ -419,7 +423,7 @@ export function installMemberSelectionRuntime(
         }
         const recorded = await failMemberOpenAttempt(ctx, stateRoot, teamId, memberName, failure, child.session, {
           captainSessionId: parentSessionId, memberId: child.id, task,
-        })
+        }, bridgeEvents)
         if (!recorded) return
         // The final-error event precedes driver quiescence. Observe the real
         // lifecycle and kick explicitly even if its idle event was missed.

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -32,6 +32,7 @@ import {
   writeTeam,
 } from './state.ts'
 import type { TeamMember, TeamState, TeamTask } from './types.ts'
+import type { AgentTeamsBridgeEventPublisher } from './bridge-runtime.ts'
 
 /** Per-dependency output cap in the assignment prompt. */
 export const DEPENDENCY_OUTPUT_MAX_CHARS = 2_000
@@ -41,6 +42,7 @@ export const DEPENDENCY_OUTPUTS_TOTAL_MAX_CHARS = 12_000
 export interface SchedulerConfig {
   readonly stateDir: string
   readonly executionPrompt?: string
+  readonly bridgeEvents?: AgentTeamsBridgeEventPublisher
 }
 
 export interface TeamScheduler {
@@ -375,6 +377,7 @@ export function installTeamScheduler(ctx: Context, config: SchedulerConfig): Tea
           else parkedAttempts.delete(currentMember.id)
           currentMember.status = 'working'
           await writeTeam(stateRoot, fresh)
+          await config.bridgeEvents?.publishActive('task-updated', stateRoot, fresh.id, task.id)
           const profileSeedId = taskProfileSeedId(task)
           const protocol = teamProfileProtocol(fresh)
           return {
@@ -450,6 +453,7 @@ export function installTeamScheduler(ctx: Context, config: SchedulerConfig): Tea
           const currentMember = fresh.members.find(candidate => candidate.name === ticket.memberName)
           if (currentMember !== undefined && currentMember.status !== 'removed') currentMember.status = 'idle'
           await writeTeam(stateRoot, fresh)
+          await config.bridgeEvents?.publishActive('task-updated', stateRoot, fresh.id, task.id)
         })
       })
     },
@@ -472,6 +476,7 @@ export function installTeamScheduler(ctx: Context, config: SchedulerConfig): Tea
       // interrupted, or the user switches conversations.
       if (status === 'running') return
       let requeued = false
+      const requeuedTaskIds: string[] = []
       await withTeamLock(teamLockKey(stateRoot, located.id), async () => {
         const fresh = await readTeam(stateRoot, located.id)
         if (fresh === undefined || fresh.captainSessionId !== agent.id) return
@@ -483,8 +488,14 @@ export function installTeamScheduler(ctx: Context, config: SchedulerConfig): Tea
           invalidateTaskAttempt(task)
           task.reassigning = false
           requeued = true
+          requeuedTaskIds.push(task.id)
         }
-        if (requeued) await writeTeam(stateRoot, fresh)
+        if (requeued) {
+          await writeTeam(stateRoot, fresh)
+          for (const taskId of requeuedTaskIds) {
+            await config.bridgeEvents?.publishActive('task-updated', stateRoot, fresh.id, taskId)
+          }
+        }
       })
       if (requeued) await runtime.kickTeam(workspace, located.id, agent)
       return

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -68,6 +68,7 @@ import {
 import { TERMINAL_TASK_STATUSES, type TeamMember, type TeamState, type TeamTask } from './types.ts'
 import { installTeamScheduler } from './scheduler.ts'
 import { resolveTeamProfile } from './profiles.ts'
+import type { AgentTeamsBridgeEventPublisher } from './bridge-runtime.ts'
 
 export { steerCaptainReport } from './members.ts'
 
@@ -89,6 +90,8 @@ export interface ToolsConfig {
   maxMembers: number
   /** Named team profiles from the active DSH profile. */
   profiles: Record<string, import('./profiles.ts').TeamProfileConfig>
+  /** Private write-side of the public read-only Bridge event bus. */
+  bridgeEvents?: AgentTeamsBridgeEventPublisher
 }
 
 /** Browser/UI mutations allowed while a plan is waiting for approval. */
@@ -357,6 +360,7 @@ export async function haltTeamWork(input: {
   teamId: string
   captain: Agent
   signal?: AbortSignal
+  bridgeEvents?: AgentTeamsBridgeEventPublisher
 }): Promise<{ teamName: string; cancelledTasks: number; alreadyHalted: boolean }> {
   const halted = await withTeamLock(teamLockKey(input.stateRoot, input.teamId), async () => {
     const fresh = await requireFreshCaptainTeam(input.stateRoot, input.teamId, input.captain.id)
@@ -382,6 +386,7 @@ export async function haltTeamWork(input: {
     fresh.halted = true
     fresh.haltedAt = now
     await writeTeam(input.stateRoot, fresh)
+    await input.bridgeEvents?.publishActive('team-halted', input.stateRoot, fresh.id)
     appendTeamEvent(input.ctx, captainSessionOf(input.ctx, fresh.captainSessionId, input.captain.session), 'agent-teams/team-halted', {
       teamId: fresh.id,
       cancelledTasks,
@@ -438,10 +443,14 @@ export function stagedPlanFeedbackContext(teamName: string): string {
  */
 export function registerAgentTeamsTools(ctx: Context, config: ToolsConfig): AgentTeamsRuntime {
   installRetiredMemberGuard(ctx, config.stateDir)
-  const scheduler = installTeamScheduler(ctx, { stateDir: config.stateDir, executionPrompt: config.executionPrompt })
+  const scheduler = installTeamScheduler(ctx, {
+    stateDir: config.stateDir,
+    executionPrompt: config.executionPrompt,
+    bridgeEvents: config.bridgeEvents,
+  })
   const memberSelections = installMemberSelectionRuntime(ctx, config.stateDir, (workspace, teamId, memberName) => (
     scheduler.kickMember(workspace, teamId, memberName)
-  ))
+  ), config.bridgeEvents)
 
   const updateStagedPlanBatch: AgentTeamsRuntime['updateStagedPlanBatch'] = async (captain, teamId, mutations, signal) => {
     if (mutations.length === 0) throw new Error('at least one staged plan operation is required')
@@ -514,6 +523,11 @@ export function registerAgentTeamsTools(ctx: Context, config: ToolsConfig): Agen
       validateStagedGraph(fresh, false)
       fresh.planReviewState = 'awaiting_review'
       await writeTeam(stateRoot, fresh)
+      for (const mutation of mutations) {
+        if (mutation.action === 'update_task') {
+          await config.bridgeEvents?.publishActive('task-updated', stateRoot, fresh.id, mutation.taskId)
+        }
+      }
       return fresh
     })
   }
@@ -573,6 +587,7 @@ export function registerAgentTeamsTools(ctx: Context, config: ToolsConfig): Agen
         delete fresh.planReviewState
         fresh.approvedAt = Date.now()
         await writeTeam(stateRoot, fresh)
+        await config.bridgeEvents?.publishActive('team-approved', stateRoot, fresh.id)
         return { teamId: fresh.id, members: fresh.members.length, tasks: fresh.tasks.length }
       } catch (error: unknown) {
         await recordRetiredMemberIds(stateRoot, spawned.map((member) => member.id)).catch(() => undefined)
@@ -645,6 +660,7 @@ export function registerAgentTeamsTools(ctx: Context, config: ToolsConfig): Agen
       // A staged plan owns no child sessions. Archiving releases the captain
       // immediately while retaining the rejected graph for later inspection.
       await archiveTeamDir(stateRoot, fresh.id)
+      await config.bridgeEvents?.publishArchived(stateRoot, fresh.id)
       return { teamId: fresh.id, teamName: fresh.name }
     })
     // Preserve this control fact for the next genuine user turn, then abort the
@@ -743,7 +759,8 @@ export function registerAgentTeamsTools(ctx: Context, config: ToolsConfig): Agen
               members: [],
               tasks: [],
               taskSeq: 0,
-              ...staged ? { phase: 'staged' as const, planReviewState: 'awaiting_review' as const } : {},
+              phase: staged ? 'staged' as const : 'running' as const,
+              ...staged ? { planReviewState: 'awaiting_review' as const } : {},
             }
             await createTeamDir(stateRoot, state)
             return { committed: true as const, state }
@@ -764,6 +781,11 @@ export function registerAgentTeamsTools(ctx: Context, config: ToolsConfig): Agen
         })
       })
       if (created.committed) {
+        await config.bridgeEvents?.publishActive(
+          created.state.phase === 'staged' ? 'team-staged' : 'team-approved',
+          stateRoot,
+          created.state.id,
+        )
         try {
           await scheduler.kickTeam(workspace, created.state.id, captain)
         } catch (error: unknown) {
@@ -1145,6 +1167,9 @@ export function registerAgentTeamsTools(ctx: Context, config: ToolsConfig): Agen
         }
         member.status = 'removed'
         await writeTeam(stateRoot, fresh)
+        for (const taskId of requeued) {
+          await config.bridgeEvents?.publishActive('task-updated', stateRoot, fresh.id, taskId)
+        }
         appendTeamEvent(ctx, captainSessionOf(ctx, fresh.captainSessionId, captain.session), 'agent-teams/member-removed', {
           teamId: fresh.id,
           memberId: member.id,
@@ -1247,6 +1272,7 @@ export function registerAgentTeamsTools(ctx: Context, config: ToolsConfig): Agen
           resumeReason: input.resumeReason,
         })
         if (!gate.ok) throw new Error(gate.error ?? 'create_task rejected by quality gates')
+        let didResume = false
         if (fresh.halted === true) {
           const resumed = resumeTeamState(fresh, args.resumeReason ?? '')
           if (resumed.status !== 'resumed' || resumed.team === undefined) {
@@ -1254,6 +1280,7 @@ export function registerAgentTeamsTools(ctx: Context, config: ToolsConfig): Agen
           }
           fresh.halted = false
           fresh.haltedAt = undefined
+          didResume = true
           appendTeamEvent(ctx, captainSessionOf(ctx, fresh.captainSessionId, captain.session), 'agent-teams/team-resumed', {
             teamId: fresh.id,
             reason: args.resumeReason ?? '',
@@ -1300,6 +1327,7 @@ export function registerAgentTeamsTools(ctx: Context, config: ToolsConfig): Agen
         fresh.taskSeq += 1
         fresh.tasks.push(task)
         await writeTeam(stateRoot, fresh)
+        if (didResume) await config.bridgeEvents?.publishActive('team-resumed', stateRoot, fresh.id)
         appendTeamEvent(ctx, captainSessionOf(ctx, fresh.captainSessionId, captain.session), 'agent-teams/task-created', {
           teamId: fresh.id,
           taskId: task.id,
@@ -1415,6 +1443,7 @@ export function registerAgentTeamsTools(ctx: Context, config: ToolsConfig): Agen
           task.updatedAt = Date.now()
         }
         await writeTeam(stateRoot, fresh)
+        await config.bridgeEvents?.publishActive('task-updated', stateRoot, fresh.id, task.id)
         appendTeamEvent(ctx, captain.session, 'agent-teams/task-updated', {
           teamId: fresh.id,
           taskId: task.id,
@@ -1520,6 +1549,7 @@ export function registerAgentTeamsTools(ctx: Context, config: ToolsConfig): Agen
         }
         const attemptId = beginTaskAttempt(task, assignee)
         await writeTeam(stateRoot, fresh)
+        await config.bridgeEvents?.publishActive('task-updated', stateRoot, fresh.id, task.id)
         appendTeamEvent(ctx, captainSessionOf(ctx, fresh.captainSessionId, caller.session), 'agent-teams/task-updated', {
           teamId: fresh.id,
           taskId: task.id,
@@ -1696,6 +1726,7 @@ export function registerAgentTeamsTools(ctx: Context, config: ToolsConfig): Agen
           ))
         }
         await writeTeam(stateRoot, fresh)
+        await config.bridgeEvents?.publishActive('task-updated', stateRoot, fresh.id, task.id)
         appendTeamEvent(ctx, captainSessionOf(ctx, fresh.captainSessionId, caller.session), 'agent-teams/task-updated', {
           teamId: fresh.id,
           taskId: task.id,
@@ -2014,6 +2045,7 @@ export function registerAgentTeamsTools(ctx: Context, config: ToolsConfig): Agen
           fresh.halted = false
           fresh.haltedAt = undefined
           await writeTeam(stateRoot, fresh)
+          await config.bridgeEvents?.publishActive('team-resumed', stateRoot, fresh.id)
           appendTeamEvent(ctx, captainSessionOf(ctx, fresh.captainSessionId, captain.session), 'agent-teams/team-resumed', {
             teamId: fresh.id,
             reason: args.reason,
@@ -2087,6 +2119,7 @@ export function registerAgentTeamsTools(ctx: Context, config: ToolsConfig): Agen
         // Archive, not delete: tasks (with their dependency graph) and the
         // mailboxes stay on disk for later review and dependency rebuilds.
         await archiveTeamDir(stateRoot, fresh.id)
+        await config.bridgeEvents?.publishArchived(stateRoot, fresh.id)
       })
       return { deleted: true, team_name: team.name }
     },
@@ -2137,7 +2170,8 @@ async function initializeProfileTeam(input: {
     ...profile.reviewPolicy === undefined ? {} : { reviewPolicy: profile.reviewPolicy },
     captainSessionId: input.captain.id,
     createdAt: now,
-    ...input.staged ? { phase: 'staged' as const, planReviewState: 'awaiting_review' as const } : {},
+    phase: input.staged ? 'staged' as const : 'running' as const,
+    ...input.staged ? { planReviewState: 'awaiting_review' as const } : {},
     members: profile.members.map((template, index) => {
       const selection = selections[index]!
       return {

--- a/tsconfig.bridge-test.json
+++ b/tsconfig.bridge-test.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": ["scripts/bridge-types.test.ts"],
+  "exclude": []
+}


### PR DESCRIPTION
## Summary

- expose a versioned, read-only `agentTeamsBridge` Cordis service and `./bridge` package export
- publish durable captain-scoped lifecycle projections with approval ordered before scheduler dispatch
- cover HMR disposal, immutable projections, subscriptions, failure isolation, archive reads, and real lifecycle paths
- prepare `0.1.16-rc.2` for the npm `next` release workflow

## Verification

- Node 24 `pnpm run typecheck`
- Node 24 `pnpm run build`
- Node 24 `pnpm run verify`
- Bridge contract tests: 8/8
- `npm pack` artifact inspection: `lib/bridge.js` and `lib/types/bridge.d.ts` present
- isolated DSH `0.1.2-rc.1` packaged-artifact runtime verification: lifecycle, cold restore, fallback, failure, and captain idle wakeup all passed

## Release

The branch declares `0.1.16-rc.2` with `publishConfig.tag=next`. After review and merge, an upstream maintainer can create and push annotated tag `v0.1.16-rc.2`; the existing OIDC workflow will rebuild, run its host matrix, publish the verified candidate to npm `next`, and create the prerelease.
