### PR TITLE
test: 会话事件写入侧防护回归测试 (refs #8)

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "update:skills": "node scripts/update-skills.mjs",
     "test:skills-updater": "node --test scripts/update-skills.test.mjs",
     "verify:skill": "node scripts/sync-skill.mjs --check",
+    "verify:events": "node scripts/verify-events.mjs",
     "verify": "node scripts/verify.mjs && node scripts/fallback-tdd.mjs && node scripts/member-failure-tdd.mjs && node scripts/quality-gates-tdd.mjs && node scripts/lifecycle-verify.mjs && node scripts/stress-verify.mjs && pnpm verify:web-routes && pnpm verify:release && pnpm verify:skill && pnpm verify:harness-contract && pnpm verify:http-body && pnpm verify:compatibility && pnpm verify:capabilities",
     "prepublishOnly": "pnpm build && pnpm verify",
     "verify:web-routes": "node scripts/web-routes-verify.mjs",

--- a/scripts/mock-dsh-session-loader.mjs
+++ b/scripts/mock-dsh-session-loader.mjs
@@ -1,0 +1,43 @@
+/**
+ * Minimal ESM loader stub for `@deepseek-ai/dsh-session`, used only by
+ * scripts/verify-events.mjs.
+ *
+ * Since rc.1 the repo installs the `@deepseek-ai/*` peer packages as
+ * devDependencies (see .npmrc), so the real session module *is* resolvable in
+ * a clean checkout. The stub is kept anyway so the regression stays
+ * deterministic: it pins the exact scenario of issue #8 — a harness build
+ * whose `KNOWN_SESSION_EVENT_TYPES` recognizes only first-party
+ * `tool-workflow/*` / `agent/*` event types and does NOT recognize the
+ * out-of-repo `agent-teams/*` vocabulary — instead of depending on whichever
+ * harness version happens to be installed.
+ *
+ * The event write-guard in src/events.ts only depends on the harness exposing
+ * a mutable `KNOWN_SESSION_EVENT_TYPES` Set (the same contract the real module
+ * satisfies), so a stub with the same shape exercises the guard exactly as the
+ * runtime does.
+ */
+const MOCK_URL = 'mock:dsh-session';
+
+const STUB_SOURCE = `
+export const KNOWN_SESSION_EVENT_TYPES = new Set([
+  'tool-workflow/run-started',
+  'tool-workflow/run-completed',
+  'agent/created',
+]);
+`;
+
+/** @type {import('node:module').ResolveHook} */
+export async function resolve(specifier, context, nextResolve) {
+  if (specifier === '@deepseek-ai/dsh-session') {
+    return { url: MOCK_URL, shortCircuit: true };
+  }
+  return nextResolve(specifier, context);
+}
+
+/** @type {import('node:module').LoadHook} */
+export async function load(url, context, nextLoad) {
+  if (url === MOCK_URL) {
+    return { format: 'module', source: STUB_SOURCE, shortCircuit: true };
+  }
+  return nextLoad(url, context);
+}

--- a/scripts/verify-events.mjs
+++ b/scripts/verify-events.mjs
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+/**
+ * Offline regression coverage for the session event write-guard (issue #8).
+ *
+ * Background: the plugin used to write `agent-teams/*` events into the
+ * captain's Session unconditionally. The harness session reader refuses any
+ * log containing an event type outside its hard-coded
+ * `KNOWN_SESSION_EVENT_TYPES` unless the event is marked ignorable
+ * (`SessionFormatUnsupportedError`), which made every session that used
+ * AgentTeams unreadable. The write side is guarded in `src/events.ts`:
+ * events are only appended when the running harness already recognizes their
+ * type, and session write failures are contained.
+ *
+ * This script pins that guard so it cannot regress — across the alpha.2+ write
+ * path (`appendTeamEvent` reading the harness `KNOWN_SESSION_EVENT_TYPES` and
+ * `captainSessionOf` resolving the captain's live Session). It stubs
+ * `@deepseek-ai/dsh-session` with a loader hook so the scenario is pinned
+ * deterministically (see scripts/mock-dsh-session-loader.mjs); it runs with
+ * zero dependencies beyond the built package (lib/ is generated from src/ by
+ * `pnpm build`, the same convention as `scripts/verify.mjs`):
+ *
+ *   pnpm build && node scripts/verify-events.mjs
+ */
+
+import { register } from 'node:module';
+
+// Must run before the first import of lib/events.js (it imports
+// '@deepseek-ai/dsh-session' at module top level).
+register('./mock-dsh-session-loader.mjs', import.meta.url);
+
+// lib/ is generated — see scripts/verify.mjs: "Requires a prior pnpm build".
+let events;
+try {
+  events = await import('../lib/events.js');
+} catch (error) {
+  console.error(`lib/ is missing or not built — run \`pnpm build\` first (${String(error).split('\n')[0]})`);
+  process.exit(1);
+}
+
+const { appendTeamEvent, captainSessionOf } = events;
+
+let failures = 0;
+function check(label, condition, detail = '') {
+  if (condition) {
+    console.log(`  PASS  ${label}`);
+  } else {
+    failures += 1;
+    console.error(`  FAIL  ${label}${detail ? ` — ${detail}` : ''}`);
+  }
+}
+
+/** The full agent-teams event vocabulary written by this plugin. */
+const AGENT_TEAMS_EVENT_TYPES = [
+  'agent-teams/team-created',
+  'agent-teams/member-added',
+  'agent-teams/member-removed',
+  'agent-teams/task-created',
+  'agent-teams/task-updated',
+  'agent-teams/message-sent',
+  'agent-teams/team-halted',
+  'agent-teams/team-resumed',
+  'agent-teams/team-deleted',
+  'agent-teams/plan-discarded',
+];
+
+const calls = [];
+const session = { append: (type, data) => calls.push([type, data]) };
+const ctx = { logger: { debug: () => {}, warn: () => {} } };
+
+console.log('dsh-agent-teams session event write-guard regression (#8)')
+
+console.log('1/4 out-of-repo event types are never written')
+for (const type of AGENT_TEAMS_EVENT_TYPES) {
+  appendTeamEvent(ctx, session, type, {});
+}
+check(
+  'all 10 agent-teams/* types are omitted from the session log',
+  calls.length === 0,
+  `expected no appends, got ${calls.length}`,
+)
+
+console.log('2/4 harness-recognized types are still written')
+appendTeamEvent(ctx, session, 'tool-workflow/run-started', { seq: 1 })
+check(
+  'known first-party type is written',
+  calls.length === 1 && calls[0][0] === 'tool-workflow/run-started',
+  `expected one append of the known type, got ${JSON.stringify(calls)}`,
+)
+appendTeamEvent(ctx, session, 'some-other/custom-type', {})
+check('unknown custom type is omitted too', calls.length === 1)
+
+console.log('3/4 session write failures are contained')
+let threw = false
+const throwingSession = {
+  append: () => {
+    throw new Error('durable record failed')
+  },
+}
+try {
+  appendTeamEvent(ctx, throwingSession, 'tool-workflow/run-started', {})
+} catch {
+  threw = true
+}
+check('append failure does not escape appendTeamEvent', !threw)
+
+console.log('4/4 captain session resolution')
+const fallback = { id: 'fallback' }
+const liveSession = { id: 'live' }
+check(
+  'offline captain falls back to the caller session',
+  captainSessionOf({ agents: { get: () => undefined } }, 'sess-captain', fallback) === fallback,
+)
+check(
+  'live captain session wins over the fallback',
+  captainSessionOf({ agents: { get: () => ({ session: liveSession }) } }, 'sess-captain', fallback) === liveSession,
+)
+
+if (failures > 0) {
+  console.error(`\n${failures} check(s) FAILED`)
+  process.exit(1)
+}
+console.log('\nall checks passed')


### PR DESCRIPTION
## Note: re-opening the original PR #12

This PR re-submits the original [#12]. It was auto-closed by GitHub with "head repository deleted" on 2026-09-04 when the author's head fork (spacexun2/dsh-agent-teams) was deleted by accident — not a rejection on the merits. The fork has been rebuilt and the branch is replayed on top of the current main (426024f).

## What it does

An offline regression test for the session event write-guard from issue #8, plus a standalone `pnpm verify:events` entry:

- `scripts/verify-events.mjs`: drives the built `lib/events.js` against a stubbed `@deepseek-ai/dsh-session` and pins four behaviors: (1) `agent-teams/*` event types the harness does not recognize are never written to the session log; (2) recognized first-party types (e.g. `tool-workflow/run-started`) are written as usual; (3) a throwing `session.append` is contained inside `appendTeamEvent`; (4) the `captainSessionOf` fallback semantics (offline captain falls back to the caller session; a live captain session wins).
- `scripts/mock-dsh-session-loader.mjs`: an ESM loader stub that pins the issue #8 scenario deterministically (a harness that only knows first-party `tool-workflow/*` / `agent/*` vocabulary), so the test does not drift with the locally installed harness version.
- `package.json`: adds `"verify:events": "node scripts/verify-events.mjs"`. As decided earlier, it stays out of the aggregate `verify` gate; the rest of the chain is untouched.

## Fit to the current write path (post-alpha.2)

The original PR targeted the 0.1.10-era write path. After the alpha.2 refactor (bf50b49 and follow-ups) the guard contract is intact: `appendTeamEvent` in `src/events.ts` still decides write/skip by the harness `KNOWN_SESSION_EVENT_TYPES`, still wraps `session.append` in try/catch, and `captainSessionOf` keeps its signature and fallback semantics. The `conversationEvents → uiConversation` rename happened on the client side and does not touch this test surface. Adaptation in this replay: the event vocabulary now covers the 10 `agent-teams/*` types in the current `src/event-types.ts` (including the newer `team-halted`, `team-resumed`, `plan-discarded`), with the stub comments updated; since rc.1 the `@deepseek-ai/*` packages are installed as devDependencies and the stub is kept anyway to pin the scenario.

## Local verification (current main + this branch, Windows / Node v24.16.0)

```
pnpm build (clean-build.mjs && tsc -p tsconfig.json && tsc -p tsconfig.client.json && tsdown) → ok
node scripts/verify-events.mjs
  1/4 out-of-repo event types are never written
    PASS  all 10 agent-teams/* types are omitted from the session log
  2/4 harness-recognized types are still written
    PASS  known first-party type is written
    PASS  unknown custom type is omitted too
  3/4 session write failures are contained
    PASS  append failure does not escape appendTeamEvent
  4/4 captain session resolution
    PASS  offline captain falls back to the caller session
    PASS  live captain session wins over the fallback
  all checks passed  (exit 0)
```

Refs #8
