### PR TITLE
fix: align module export name with package name (@nanmicoder/dsh-agent-teams)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -50,7 +50,7 @@ const WEB_SERVER_KEYS = ['webServer', 'httpServer'] as const
 /** Workspace registry service key candidates, newest first. */
 const WORKSPACE_KEYS = ['workspaceRegistry', 'workspace'] as const
 
-export const name = 'agent-teams'
+export const name = '@nanmicoder/dsh-agent-teams'
 export const inject = ['tools', 'llm', 'subagents', 'systemPrompt', 'agents']
 
 /** Plugin configuration. */


### PR DESCRIPTION
## Note: re-opening the original PR #73

This PR re-submits the original [#73]. It was auto-closed by GitHub with "head repository deleted" on 2026-09-04 when the author's head fork (spacexun2/dsh-agent-teams) was deleted by accident — not a rejection on the merits. The fork has been rebuilt and the branch is replayed on top of the current main (426024f).

## Where things stand

The mismatch is still present on current main: `src/index.ts` still exports `export const name = 'agent-teams'` (line 53 at 426024f) while the `package.json` name is `@nanmicoder/dsh-agent-teams`. The `cordis.patch.yml` insert name and the client bundle's `__ModuleLoader__` registration id already use the package name, and the "1/8 packaging contract" section of `scripts/verify.mjs` checks both of those — the module export name is the only one of the three without a gate, which is exactly where this PR aims.

## The change

A one-line fix: `export const name` in `src/index.ts` becomes `'@nanmicoder/dsh-agent-teams'`, satisfying the dsh plugin contract's identity rule (module export name = package.json name — the same rule the bundle patch insert name and loader id already follow). This removes the `dsh plugin check` error and the latent hazard for anything that indexes plugins by name later (patch targeting, telemetry, session attribution).

Fixes #54

## Local verification (Windows / Node v24.16.0, current main + this branch)

- `tsc -p tsconfig.json --noEmit && tsc -p tsconfig.client.json --noEmit` → pass
- `pnpm build` (clean-build.mjs + tsc × 2 + tsdown) → ok
- `node scripts/verify.mjs` main gate → all 8 sections PASS ("all checks passed")
- The remaining standalone scripts: fallback-tdd / member-failure-tdd / quality-gates-tdd / stress-verify / web-routes-verify / release-metadata.test / http-body.test all PASS. lifecycle-verify failed once inside a batch loop, then passed twice when run standalone (transient jitter in the batch run, unrelated to the change)
