### PR TITLE
fix(state): release withTeamLock map entries after the last waiter leaves (fixes #142)

### DIFF
--- a/scripts/verify.mjs
+++ b/scripts/verify.mjs
@@ -26,6 +26,7 @@ import {
   readTeam,
   removeTeamDir,
   sanitizeKey,
+  teamLockQueueKeys,
   transitionError,
   unsatisfiedDependencies,
   withTeamLock,
@@ -683,6 +684,38 @@ try {
   check('mailbox accepts BOM-prefixed JSONL records', inbox[1]?.content === second.content)
   check('mailbox skips malformed JSON and malformed shapes', inbox.length === 2 && malformedLines.join(',') === '3,4')
   check('missing mailbox reads empty', (await readMailbox(stateRoot, team.id, 'nobody')).length === 0)
+
+  // The per-team lock queue must stay serial, hand off to later waiters, and
+  // must not leak one resolved promise chain per key after the last waiter.
+  const serialKey = 'lock-cleanup:serial'
+  const order = []
+  let inside = 0
+  let maxInside = 0
+  await Promise.all(Array.from({ length: 25 }, (_, index) => withTeamLock(serialKey, async () => {
+    inside += 1
+    maxInside = Math.max(maxInside, inside)
+    order.push(index)
+    await new Promise((resolve) => setTimeout(resolve, index % 3 === 0 ? 5 : 1))
+    inside -= 1
+  })))
+  check('withTeamLock keeps same-key workers strictly serial and ordered',
+    maxInside === 1 && order.join(',') === Array.from({ length: 25 }, (_, index) => index).join(','))
+  check('withTeamLock queue entry drains after the last waiter settles',
+    !teamLockQueueKeys().includes(serialKey))
+
+  const handoffKey = 'lock-cleanup:handoff'
+  let releaseHold
+  const heldGate = new Promise((resolve) => { releaseHold = resolve })
+  let successorEntered = false
+  const hold = withTeamLock(handoffKey, async () => { await heldGate })
+  const successor = withTeamLock(handoffKey, async () => { successorEntered = true })
+  await new Promise((resolve) => setTimeout(resolve, 20))
+  check('withTeamLock keeps its queue entry while the lock is held or handed off',
+    teamLockQueueKeys().includes(handoffKey))
+  releaseHold()
+  await Promise.all([hold, successor])
+  check('withTeamLock wakes the queued successor and drops the key afterwards',
+    successorEntered && !teamLockQueueKeys().includes(handoffKey))
 
   const duplicateCaptain = { ...team, id: 'duplicate-captain', members: [] }
   await createTeamDir(stateRoot, duplicateCaptain)

--- a/src/state.ts
+++ b/src/state.ts
@@ -61,13 +61,27 @@ export async function withTeamLock<T>(key: string, fn: () => Promise<T>): Promis
   const previous = locks.get(key) ?? Promise.resolve()
   let release!: () => void
   const gate = new Promise<void>((resolve) => { release = resolve })
-  locks.set(key, previous.then(() => gate))
+  const tail = previous.then(() => gate)
+  locks.set(key, tail)
   await previous
   try {
     return await fn()
   } finally {
     release()
+    // Drop this key's queue entry once we are still its tail, so settled
+    // teams do not leave one resolved promise chained forever (the same
+    // cleanup discipline as the scheduler's serializeMember). A successor
+    // that already appended itself owns the map slot; keep its entry.
+    if (locks.get(key) === tail) locks.delete(key)
   }
+}
+
+/**
+ * Keys with an in-process lock queue (held or waiting), snapshot for
+ * diagnostics and leak checks. The queue promises themselves stay private.
+ */
+export function teamLockQueueKeys(): readonly string[] {
+  return [...locks.keys()]
 }
 
 /** Longest key emitted before truncating and appending a digest. */


### PR DESCRIPTION
排查 #117 时发现的独立卫生问题,完整分析在 #142。`withTeamLock` 的 `locks` Map 在 `finally` 里只 release 不删条目,每个 `team:<stateRoot>:<teamId>` 锁 key 留一条已 resolve 的 promise 链,随团队创建/删除单调增长。

修复与 `serializeMember`(scheduler.ts:276-289)的清理完全同构:先捕获队列尾,`finally` 中比对后再删——后到者已经接管 map 槽位时不会误删,串行语义不变。

先说清楚边界:单条占用是字节级,这个修复不是 #117 内存问题的根因,解决的是不该存在的单调增长本身;#117 的排查继续在那边进行。

验证:

- `scripts/verify.mjs` state 段新增 4 项检查:25 个同 key worker 严格串行且 FIFO 有序;队列条目在最后一个 waiter 结束后清除;持有与交接期间条目存在;后到者被唤醒且随后 key 消失。
- 红测:仅移除 delete 行(保留其余)重建后,恰好 2 项清理检查 FAIL、串行检查仍 PASS——断言对准的是清理本身。
- tsc --noEmit、全量 build、verify 链逐项全绿。

实现说明:为让"清空"可断言,新增了模块级诊断导出 `teamLockQueueKeys()`(`locks` 是模块私有 Map,没有观测面就无法测试清理)。只读快照,不进包入口 API 面,仅测试深路径引用;如果维护者倾向不加导出面,可以改为不导出+仅靠行为断言,听维护者意见。
