### PR TITLE
feat(scheduler): add maxConcurrentWorkers global dispatch cap (refs #97)

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Defaults work without extra setup. A trusted profile can override member behavio
     memberModel: deepseek-v4
     memberMaxDepth: 1
     maxMembers: 8
+    maxConcurrentWorkers: 0       # per-team cap of concurrently dispatched member workers (0 = unlimited)
 ```
 
 `memberProvider` is the sub-agent runtime backend (`spawn` / `fork`), not an LLM provider. Cross-LLM-provider routing uses the optional `provider` + `model` fields of `agent_teams_add_member`; `memberModel` is only a model default for all members. A member on the captain's current provider/model inherits the captain's reasoning effort, while a changed provider or model automatically uses the target model's default. To request a particular effort, pass the optional `reasoning_effort` field — one of the target model's supported effort ids, or `"default"` to force the model's own default.

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -125,6 +125,7 @@ npm 默认标签 `latest` 现指向 `0.1.17-rc.1`，因此新 profile 使用 `ds
     memberModel: deepseek-v4
     memberMaxDepth: 1
     maxMembers: 8
+    maxConcurrentWorkers: 0       # 单团队同时派工的成员并发上限（0 = 不限）
 ```
 
 这里的 `memberProvider` 指子 Agent 的运行后端（`spawn` / `fork`），不是 LLM provider。跨 LLM provider 由 `agent_teams_add_member` 的可选 `provider` + `model` 参数表达；`memberModel` 只是所有成员的模型默认覆盖。成员沿用队长当前 provider/model 时会继承队长的思考强度；provider 或 model 任一改变时会自动使用目标模型的默认档。需要指定特定强度时，可传入可选的 `reasoning_effort` 参数（目标模型支持的档位 id，或 `"default"` 表示强制使用模型自身默认档）。

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -74,6 +74,7 @@
     memberModel: deepseek-v4      # 可选：成员模型覆盖
     memberMaxDepth: 1             # 成员再委派深度上限（0 = 禁止）
     maxMembers: 8                 # 团队人数上限
+    maxConcurrentWorkers: 0       # 单团队同时派工的成员并发上限（0 = 不限）
     executionPrompt: |            # 注入成员 persona 与每次任务派工
       The document does not need to record the process; it should only record facts, unless I explicitly request the process to be recorded.
       The product interface should present the intended outcome, not reveal the reasoning process.

--- a/scripts/lifecycle-verify.mjs
+++ b/scripts/lifecycle-verify.mjs
@@ -1393,9 +1393,9 @@ try {
   emitTurnError(flake, { code: 'STREAM_CLOSED', message: 'SSE stream ended without [DONE]' })
   // Degraded non-atomic overwrites can hand a reader torn JSON; retry the
   // durable reads instead of letting environmental I/O noise fail the checks.
-  const readTeamStable = async (teamId) => {
+  const readTeamStable = async (teamId, root = stateRoot) => {
     for (let attempt = 0; ; attempt += 1) {
-      try { return await readTeam(stateRoot, teamId) } catch (error) { if (attempt >= 5) throw error }
+      try { return await readTeam(root, teamId) } catch (error) { if (attempt >= 5) throw error }
     }
   }
   const readMailboxStable = async (teamId, agentKey) => {
@@ -1430,6 +1430,127 @@ try {
       && (await readUnreadMailbox(stateRoot, 'failure-bridge', 'flake')).length === 0
       && (await bridgeTask())?.status === 'failed')
   await call('agent_teams_delete', {})
+
+  // ── member concurrency budget (issue #97) ────────────────────────────
+  // A second plugin registration with maxConcurrentWorkers=2 reuses the same
+  // fake harness but keeps its own state root, so the budget applies only to
+  // this team. Each open (claimed/in_progress) task held by a member occupies
+  // one license; captain takeovers do not count, and cold recovery of an
+  // unobserved durable attempt must never be blocked by a saturated budget.
+  const capDefinitions = new Map()
+  const capCtx = {
+    ...ctx,
+    tools: { register(definition) { capDefinitions.set(definition.name, definition) } },
+  }
+  registerAgentTeamsTools(capCtx, {
+    stateDir: '.agent-teams-capped',
+    memberProvider: 'spawn',
+    memberMaxDepth: 1,
+    maxMembers: 8,
+    maxConcurrentWorkers: 2,
+    profiles: {},
+  })
+  const capCall = (name, args, subject = captain) => {
+    const definition = capDefinitions.get(name)
+    if (!definition) throw new Error(`missing tool ${name}`)
+    return definition.execute(args, execFor(subject))
+  }
+  const cappedRoot = join(workspace, '.agent-teams-capped')
+  const cappedState = () => readTeamStable('capped-concurrency', cappedRoot)
+  const cappedTask = async id => (await cappedState())?.tasks.find(candidate => candidate.id === id)
+  const cappedOpen = async () => (await cappedState())?.tasks
+    .filter(candidate => candidate.status === 'claimed' || candidate.status === 'in_progress')
+    .length ?? 0
+  const capSettle = async (label, predicate) => {
+    for (let waited = 0; waited < 4000; waited += 20) {
+      if (await predicate()) return
+      await new Promise(resolve => setTimeout(resolve, 20))
+    }
+    check(label, false, 'timed out waiting for the expected team state')
+  }
+
+  await capCall('agent_teams_create', { name: 'Capped Concurrency', description: 'worker budget' })
+  for (let index = 1; index <= 7; index += 1) {
+    await capCall('agent_teams_add_member', { name: `worker-${index}`, role: 'builder' })
+  }
+  const capTaskIds = []
+  for (let index = 1; index <= 7; index += 1) {
+    capTaskIds.push((await capCall('agent_teams_create_task', { subject: `capped unit ${index}` })).task_id)
+  }
+  const capWorkers = ((await cappedState())?.members ?? [])
+    .filter(member => member.status !== 'removed')
+    .map(member => liveAgents.get(member.id))
+
+  // Idle workers one at a time: only the first two take the two licenses.
+  const deliveriesBeforeCapWave = deliveries.length
+  publishStatus(capWorkers[0], 'idle')
+  await capSettle('first idle worker is dispatched under the cap',
+    async () => (await cappedTask(capTaskIds[0]))?.status === 'claimed')
+  publishStatus(capWorkers[1], 'idle')
+  await capSettle('second idle worker fills the concurrency budget',
+    async () => (await cappedTask(capTaskIds[1]))?.status === 'claimed')
+  for (let index = 2; index < 7; index += 1) publishStatus(capWorkers[index], 'idle')
+  await new Promise(resolve => setTimeout(resolve, 60))
+  check('cap keeps the remaining five ready tasks pending and members idle (#97)',
+    await cappedOpen() === 2
+      && (await cappedState()).tasks.filter(candidate => candidate.status === 'pending').length === 5
+      && deliveries.length === deliveriesBeforeCapWave + 2
+      && (await cappedState()).members
+        .filter(member => /^worker-[3-7]$/.test(member.name))
+        .every(member => member.status === 'idle'))
+
+  // Completing one task frees its license at the graph-kick boundary; exactly
+  // one queued task may then be dispatched.
+  const firstClaim = await capCall('agent_teams_claim_task', { task_id: capTaskIds[0] }, capWorkers[0])
+  await capCall('agent_teams_update_task', {
+    task_id: capTaskIds[0], status: 'in_progress', attempt_id: firstClaim.attempt_id,
+  }, capWorkers[0])
+  await capCall('agent_teams_update_task', {
+    task_id: capTaskIds[0], status: 'completed', output: 'unit 1 done', attempt_id: firstClaim.attempt_id,
+  }, capWorkers[0])
+  await capSettle('completion frees exactly one license for the next queued task',
+    async () => (await cappedTask(capTaskIds[2]))?.status === 'claimed')
+  publishStatus(capWorkers[0], 'idle')
+  await new Promise(resolve => setTimeout(resolve, 60))
+  check('saturated budget blocks the freed member from extra queued work (#97)',
+    await cappedOpen() === 2
+      && (await cappedTask(capTaskIds[2]))?.assignee === 'worker-3'
+      && (await cappedTask(capTaskIds[3]))?.status === 'pending'
+      && (await cappedState()).members.find(member => member.name === 'worker-1')?.status === 'idle')
+
+  // A member failure path must release its license instead of wedging the
+  // queue: the failed attempt is terminal and the next queued task dispatches.
+  const secondClaim = await capCall('agent_teams_claim_task', { task_id: capTaskIds[1] }, capWorkers[1])
+  await capCall('agent_teams_update_task', {
+    task_id: capTaskIds[1], status: 'in_progress', attempt_id: secondClaim.attempt_id,
+  }, capWorkers[1])
+  await capCall('agent_teams_update_task', {
+    task_id: capTaskIds[1], status: 'failed', output: 'blocked on missing input', attempt_id: secondClaim.attempt_id,
+  }, capWorkers[1])
+  await capSettle('failed attempt releases its license to the queue',
+    async () => (await cappedTask(capTaskIds[3]))?.status === 'claimed')
+  publishStatus(capWorkers[1], 'idle')
+  await new Promise(resolve => setTimeout(resolve, 60))
+  check('failure keeps one failed task and exactly two fresh open tasks (#97)',
+    (await cappedTask(capTaskIds[1]))?.status === 'failed'
+      && await cappedOpen() === 2
+      && (await cappedState()).tasks.filter(candidate => candidate.status === 'pending').length === 3
+      && (await cappedState()).members.find(member => member.name === 'worker-2')?.status === 'idle')
+
+  // Cold recovery of an unobserved durable attempt bypasses the budget: with
+  // both licenses still held and the owner's handle disposed, the exact next
+  // kick must still rotate that one attempt instead of wedging behind #97.
+  const thirdBefore = await cappedTask(capTaskIds[2])
+  liveAgents.delete(capWorkers[2].id)
+  await capCall('agent_teams_status', {})
+  await new Promise(resolve => setTimeout(resolve, 60))
+  const thirdAfter = await cappedTask(capTaskIds[2])
+  check('recovery dispatch is never blocked by a saturated budget (#86/#97)',
+    thirdAfter?.status === 'claimed'
+      && thirdAfter?.attempt === (thirdBefore?.attempt ?? 0) + 1
+      && thirdAfter?.attemptId !== thirdBefore?.attemptId
+      && await cappedOpen() === 2)
+  await capCall('agent_teams_delete', {})
 } finally {
   await rm(workspace, { recursive: true, force: true })
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,6 +72,14 @@ export interface Config {
   memberMaxDepth?: number
   /** Team size cap in members (default `8`). */
   maxMembers?: number
+  /**
+   * Per-team cap of member workers dispatched concurrently — counted as open
+   * (`claimed`/`in_progress`) tasks held by current members (default `0`,
+   * unlimited, which matches the pre-#97 behavior). Captain takeovers do not
+   * count toward the budget, and cold recovery of an unobserved durable
+   * attempt is never blocked by it.
+   */
+  maxConcurrentWorkers?: number
   /** Named multi-role team profiles. */
   profiles?: Record<string, TeamProfileConfig>
   /** Prompt-section order for the usage policy (default `117`, after delegation policy). */
@@ -130,6 +138,7 @@ export const Config: z<Config> = z.object({
   })).default({}),
   memberMaxDepth: z.natural().default(1),
   maxMembers: z.natural().min(1).default(8),
+  maxConcurrentWorkers: z.natural().default(0),
   promptSectionOrder: z.natural().default(117),
   slashCommand: z.boolean().default(true),
 })
@@ -159,6 +168,7 @@ export function apply(ctx: Context, config: Config): void {
     fallback: config.fallback,
     memberMaxDepth: config.memberMaxDepth ?? 1,
     maxMembers: config.maxMembers ?? 8,
+    maxConcurrentWorkers: config.maxConcurrentWorkers ?? 0,
     profiles: config.profiles ?? {},
   }
 

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -41,6 +41,12 @@ export const DEPENDENCY_OUTPUTS_TOTAL_MAX_CHARS = 12_000
 export interface SchedulerConfig {
   readonly stateDir: string
   readonly executionPrompt?: string
+  /**
+   * Per-team cap of member workers dispatched concurrently, counted as open
+   * (`claimed`/`in_progress`) tasks held by current members. `0`/undefined is
+   * unlimited and matches the pre-#97 behavior.
+   */
+  readonly maxConcurrentWorkers?: number
 }
 
 export interface TeamScheduler {
@@ -361,6 +367,30 @@ export function installTeamScheduler(ctx: Context, config: SchedulerConfig): Tea
               await writeTeam(stateRoot, fresh)
             }
             return undefined
+          }
+          // Concurrency budget (#97): only genuinely new dispatches consume a
+          // worker license. The in-flight count is the open (`claimed` or
+          // `in_progress`) tasks held by current members. Two explicit
+          // decisions: captain takeovers do not count, because the captain is
+          // a single extra lane outside the member worker pool; and cold
+          // recovery of an unobserved durable attempt bypasses the cap, so a
+          // saturated budget can never wedge restart recovery (#86) behind
+          // the queue.
+          const cap = config.maxConcurrentWorkers ?? 0
+          if (!recoverOwned && cap > 0) {
+            const holders = new Set(
+              fresh.members.filter(candidate => candidate.status !== 'removed').map(candidate => candidate.name),
+            )
+            const inflight = fresh.tasks.filter(candidate => (
+              (candidate.status === 'claimed' || candidate.status === 'in_progress')
+              && candidate.assignee !== undefined
+              && holders.has(candidate.assignee)
+            )).length
+            if (inflight >= cap) {
+              // Leave the task pending and the member idle; write nothing so
+              // later idle/graph kicks re-run this decision for free.
+              return undefined
+            }
           }
           const previousAssignee = task.assignee
           const previousStatus = recoverOwned ? task.status as 'claimed' | 'in_progress' : undefined

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -87,6 +87,8 @@ export interface ToolsConfig {
   memberMaxDepth?: number
   /** Team size cap (members). */
   maxMembers: number
+  /** Per-team cap of concurrently dispatched member workers (`0` = unlimited). */
+  maxConcurrentWorkers?: number
   /** Named team profiles from the active DSH profile. */
   profiles: Record<string, import('./profiles.ts').TeamProfileConfig>
 }
@@ -449,7 +451,11 @@ export function stagedPlanFeedbackContext(teamName: string): string {
  */
 export function registerAgentTeamsTools(ctx: Context, config: ToolsConfig): AgentTeamsRuntime {
   installRetiredMemberGuard(ctx, config.stateDir)
-  const scheduler = installTeamScheduler(ctx, { stateDir: config.stateDir, executionPrompt: config.executionPrompt })
+  const scheduler = installTeamScheduler(ctx, {
+    stateDir: config.stateDir,
+    executionPrompt: config.executionPrompt,
+    maxConcurrentWorkers: config.maxConcurrentWorkers,
+  })
   const memberSelections = installMemberSelectionRuntime(ctx, config.stateDir, (workspace, teamId, memberName) => (
     scheduler.kickMember(workspace, teamId, memberName)
   ))


### PR DESCRIPTION
Background: #97 — when members are all ready the whole team starts working in parallel, hits 429/quota, and then stalls until a human intervenes. In the #97 design comment the maintainer drew the boundary as three things (concurrency permits, queue fairness, failure release) and separated retryable 429s from insufficient_quota that needs a route change (the latter belongs to host fallback; `FALLBACK_FAILURE_CODES` in members.ts already covers it). This PR implements the first slice: an opt-in per-team dispatch concurrency limit (one global config value). 429 backoff is deliberately left out of the plugin to avoid overlapping host llm-retry.

Changes:

- `Config`/`ToolsConfig` gains `maxConcurrentWorkers` (`z.natural().default(0)`, 0 = unlimited). At the default the behavior is path-for-path identical to today (the whole guard is gated on cap > 0).
- The count and gate live inside the ticket transaction: after a task is selected and before `beginTaskAttempt`, count claimed/in_progress tasks held by non-removed members; at the cap, a new dispatch returns undefined — the task stays pending, the member stays idle, nothing is written. Dispatch is already event-driven, so graph changes and member idle edges re-kick; queueing and backfill need no new polling.
- The `recoverOwned` recovery path is exempt from the cap so the parked recovery from #86 does not get blocked.
- Explicit decision (documented in code comments): only member-held tasks are counted; captain takeover is not — the captain's take-over and cleanup actions should not be blocked by a member concurrency limit.
- Docs: one row each in README.md / README_ZH.md / docs/usage.md.

Two semantic boundaries, stated explicitly:

1. On a cap hit the gate writes nothing; member state is not rewritten through this path. If a member has a stale working state, the existing status sync converges it — the gate does not correct it.
2. `recoverOwned` recovery ignores the cap, and a recovered task counts toward the in-flight number like any member task — a long-parked task therefore keeps holding a permit slot. That is the current, deliberate semantics; happy to adjust in discussion if it does not match expectations.

Verification:

- lifecycle-verify gains cap scenarios (a second plugin instance on the shared fake harness, separate stateDir): 7 members with 7 ready tasks and cap=2 → exactly 2 dispatched, 5 pending; complete one → exactly the third gets dispatched; a member failure → permit released, queue not stuck; cold restore still rotates attempts while the cap is full.
- Two red-test mutations against a build without the feature: deleting the guard → exactly the 4 cap checks FAIL; deleting only the recoverOwned exemption → exactly the fourth FAILs, the rest PASS. The assertions target the feature and its exemption specifically.
- tsc --noEmit on both tsconfigs, the full build, the verify chain item by item (verify main gate, fallback-tdd, member-failure-tdd, quality-gates-tdd, stress-verify, web-routes, harness-compat-tdd, etc.) and lifecycle-verify in both classic and --modern-harness variants, all green.

Known scope note: queue fairness (ordering when several tasks contend for one permit) is not changed by this PR — it keeps nextReadyTask's assigned-first ordering. If #97 wants explicit fairness semantics later, that deserves its own discussion.
